### PR TITLE
Fix zooming in ResultHitPoints

### DIFF
--- a/fluXis.Game/Screens/Result/UI/ResultHitPoints.cs
+++ b/fluXis.Game/Screens/Result/UI/ResultHitPoints.cs
@@ -132,10 +132,10 @@ public partial class ResultHitPoints : Container
 
         foreach (var result in Score.HitResults)
         {
-            var statTime = result.Time - MapInfo.StartTime;
+            var startTime = result.Time - MapInfo.StartTime;
             var endTime = MapInfo.EndTime - MapInfo.StartTime;
 
-            var x = (int)((image.Width - padding * 2) * (statTime == endTime ? .5f : statTime / endTime)) + padding;
+            var x = (int)((image.Width - padding * 2) * (startTime == endTime ? .5f : startTime / endTime)) + padding;
             var y = (int)(image.Height / 2f - result.Difference * max_zoom);
 
             var colour4 = skinManager.CurrentSkin.GetColorForJudgement(result.Judgement);
@@ -228,7 +228,21 @@ public partial class ResultHitPoints : Container
 
     protected override bool OnScroll(ScrollEvent e)
     {
-        hitResults.ScaleTo(MathHelper.Clamp(hitResults.Scale.X + e.ScrollDelta.Y / 2f, 1f, max_zoom), 100, Easing.OutQuint);
+        var scale = MathHelper.Clamp(hitResults.Scale.X + e.ScrollDelta.Y / 2f, 1f, max_zoom);
+        hitResults.ScaleTo(scale, 100, Easing.OutQuint);
+        float maxX = hitResults.DrawWidth / 2f * scale;
+        float maxY = hitResults.DrawHeight / 2f * scale;
+
+        if (Math.Abs(hitResults.X) >= maxX)
+        {
+            hitResults.MoveToX(MathHelper.Clamp(hitResults.X, -maxX, maxX), 100, Easing.OutQuint);
+        }
+
+        if (Math.Abs(hitResults.Y) >= maxY)
+        {
+            hitResults.MoveToY(MathHelper.Clamp(hitResults.Y, -maxY, maxY), 100, Easing.OutQuint);
+        }
+
         return true;
     }
 


### PR DESCRIPTION
When zooming out while on the edge of the image, due to lack of position clamping, the image would disappear entirely. This PR fixes the issue by clamping the position on zoom.

Also fixes a typo in the same file

Before:

https://github.com/TeamFluXis/fluXis/assets/24654479/d0a3027d-bdb8-423a-b7ea-eb33b515f12d

After:

https://github.com/TeamFluXis/fluXis/assets/24654479/9d617453-bb98-4b67-8726-2f1da425402d

