### PR TITLE
Include Java 11.0 in Android builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-java@v4.0.0
         with:
           distribution: microsoft
+          java-version: 11.0
 
       - name: build
         run: dotnet publish fluXis.Android --output ./bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
-
-      - name: Setup Java JDK
-        uses: actions/setup-java@v4.0.0
-        with:
-          distribution: microsoft
           
       - name: build
         run: dotnet publish fluXis.Desktop --output ./bin
@@ -77,6 +72,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
+ 
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: microsoft
 
       - name: build
         run: dotnet publish fluXis.Android --output ./bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 name: CI
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: microsoft
+          
       - name: build
         run: dotnet publish fluXis.Desktop --output ./bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
-          
+
       - name: build
         run: dotnet publish fluXis.Desktop --output ./bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 name: CI
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This minor modification to the CI file makes it so that Android builds can finally happen again! Now I can rest easy knowing that checks can finally pass and FluXis on Android is becoming a reality once again.