### PR TITLE
Improve editor actions struct

### DIFF
--- a/fluXis.Game/Screens/Edit/Actions/ApplyOffsetAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/ApplyOffsetAction.cs
@@ -3,16 +3,13 @@ namespace fluXis.Game.Screens.Edit.Actions;
 public class ApplyOffsetAction : EditorAction
 {
     public override string Description => $"Add offset of {offset}ms to everything";
-
-    private EditorMap map { get; }
     private float offset { get; }
 
-    public ApplyOffsetAction(EditorMap map, float offset)
+    public ApplyOffsetAction(float offset)
     {
-        this.map = map;
         this.offset = offset;
     }
 
-    public override void Run() => map.ApplyOffsetToAll(offset);
-    public override void Undo() => map.ApplyOffsetToAll(-offset);
+    public override void Run(EditorMap map) => map.ApplyOffsetToAll(offset);
+    public override void Undo(EditorMap map) => map.ApplyOffsetToAll(-offset);
 }

--- a/fluXis.Game/Screens/Edit/Actions/EditorAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/EditorAction.cs
@@ -3,7 +3,7 @@ namespace fluXis.Game.Screens.Edit.Actions;
 public abstract class EditorAction
 {
     public abstract string Description { get; }
-    public abstract void Run();
-    public abstract void Undo();
+    public abstract void Run(EditorMap map);
+    public abstract void Undo(EditorMap map);
 }
 

--- a/fluXis.Game/Screens/Edit/Actions/EditorActionStack.cs
+++ b/fluXis.Game/Screens/Edit/Actions/EditorActionStack.cs
@@ -16,6 +16,13 @@ public class EditorActionStack
     [CanBeNull]
     public NotificationManager NotificationManager { get; init; }
 
+    private readonly EditorMap editorMap;
+
+    public EditorActionStack(EditorMap editorMap)
+    {
+        this.editorMap = editorMap;
+    }
+
     public void Add(EditorAction action)
     {
         if (index < 0)
@@ -23,7 +30,7 @@ public class EditorActionStack
         else if (index < stack.Count - 1)
             stack.RemoveRange(index, stack.Count - index);
 
-        action.Run();
+        action.Run(editorMap);
         stack.Add(action);
         index = stack.Count - 1;
     }
@@ -37,7 +44,7 @@ public class EditorActionStack
         }
 
         var action = stack[index];
-        action.Undo();
+        action.Undo(editorMap);
 
         var desc = action.Description;
 
@@ -58,7 +65,7 @@ public class EditorActionStack
         index++;
 
         var action = stack[index];
-        action.Run();
+        action.Run(editorMap);
 
         var desc = action.Description;
 

--- a/fluXis.Game/Screens/Edit/Actions/Notes/Hitsound/NoteHitsoundChangeAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/Notes/Hitsound/NoteHitsoundChangeAction.cs
@@ -8,20 +8,18 @@ public class NoteHitsoundChangeAction : EditorAction
     public override string Description => $"Change sounds of {infos.Length} note(s) to {newSample}";
 
     private HitObject[] infos { get; }
-    private EditorMap map { get; }
     private string newSample { get; }
     private string[] samples { get; }
 
-    public NoteHitsoundChangeAction(EditorMap map, HitObject[] infos, string newSample)
+    public NoteHitsoundChangeAction(HitObject[] infos, string newSample)
     {
-        this.map = map;
         this.infos = infos;
         this.newSample = newSample;
 
         samples = infos.Select(i => i.HitSound).ToArray();
     }
 
-    public override void Run()
+    public override void Run(EditorMap map)
     {
         foreach (var info in infos)
             info.HitSound = newSample;
@@ -29,7 +27,7 @@ public class NoteHitsoundChangeAction : EditorAction
         map.UpdateHitSounds();
     }
 
-    public override void Undo()
+    public override void Undo(EditorMap map)
     {
         for (int i = 0; i < infos.Length; i++)
             infos[i].HitSound = samples[i];

--- a/fluXis.Game/Screens/Edit/Actions/Notes/NotePasteAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/Notes/NotePasteAction.cs
@@ -7,21 +7,19 @@ public class NotePasteAction : EditorAction
     public override string Description => $"Paste {infos.Length} note(s)";
 
     private HitObject[] infos { get; }
-    private EditorMap map { get; }
 
-    public NotePasteAction(HitObject[] infos, EditorMap map)
+    public NotePasteAction(HitObject[] infos)
     {
         this.infos = infos;
-        this.map = map;
     }
 
-    public override void Run()
+    public override void Run(EditorMap map)
     {
         foreach (var info in infos)
             map.Add(info);
     }
 
-    public override void Undo()
+    public override void Undo(EditorMap map)
     {
         foreach (var info in infos)
             map.Remove(info);

--- a/fluXis.Game/Screens/Edit/Actions/Notes/NotePlaceAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/Notes/NotePlaceAction.cs
@@ -6,14 +6,12 @@ public class NotePlaceAction : EditorAction
 {
     public override string Description => $"Place note at {(int)info.Time}ms on lane {info.Lane}";
     private HitObject info { get; }
-    private EditorMap map { get; }
 
-    public NotePlaceAction(HitObject info, EditorMap map)
+    public NotePlaceAction(HitObject info)
     {
         this.info = info;
-        this.map = map;
     }
 
-    public override void Run() => map.Add(info);
-    public override void Undo() => map.Remove(info);
+    public override void Run(EditorMap map) => map.Add(info);
+    public override void Undo(EditorMap map) => map.Remove(info);
 }

--- a/fluXis.Game/Screens/Edit/Actions/Notes/NoteRemoveAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/Notes/NoteRemoveAction.cs
@@ -6,21 +6,19 @@ public class NoteRemoveAction : EditorAction
 {
     public override string Description => $"Remove {infos.Length} note(s)";
     private HitObject[] infos { get; }
-    private EditorMap map { get; }
 
-    public NoteRemoveAction(HitObject[] infos, EditorMap map)
+    public NoteRemoveAction(HitObject[] infos)
     {
         this.infos = infos;
-        this.map = map;
     }
 
-    public override void Run()
+    public override void Run(EditorMap map)
     {
         foreach (var info in infos)
             map.Remove(info);
     }
 
-    public override void Undo()
+    public override void Undo(EditorMap map)
     {
         foreach (var info in infos)
             map.Add(info);

--- a/fluXis.Game/Screens/Edit/Actions/Notes/Shortcuts/NoteFlipAction.cs
+++ b/fluXis.Game/Screens/Edit/Actions/Notes/Shortcuts/NoteFlipAction.cs
@@ -16,15 +16,21 @@ public class NoteFlipAction : EditorAction
         this.keyCount = keyCount;
     }
 
-    public override void Run()
+    public override void Run(EditorMap map)
     {
         foreach (var note in notes)
+        {
             note.Lane = keyCount - note.Lane + 1;
+            map.Update(note);
+        }
     }
 
-    public override void Undo()
+    public override void Undo(EditorMap map)
     {
         foreach (var note in notes)
+        {
             note.Lane = keyCount - note.Lane + 1;
+            map.Update(note);
+        }
     }
 }

--- a/fluXis.Game/Screens/Edit/Editor.cs
+++ b/fluXis.Game/Screens/Edit/Editor.cs
@@ -361,7 +361,7 @@ public partial class Editor : FluXisScreen, IKeyBindingHandler<FluXisGlobalKeybi
     {
         panels.Content = new EditorOffsetPanel
         {
-            OnApplyOffset = offset => actionStack.Add(new ApplyOffsetAction(editorMap, offset))
+            OnApplyOffset = offset => actionStack.Add(new ApplyOffsetAction(offset))
         };
     }
 

--- a/fluXis.Game/Screens/Edit/Editor.cs
+++ b/fluXis.Game/Screens/Edit/Editor.cs
@@ -159,7 +159,7 @@ public partial class Editor : FluXisScreen, IKeyBindingHandler<FluXisGlobalKeybi
         dependencies.CacheAs(this);
         dependencies.CacheAs(editorMap);
         dependencies.CacheAs(Waveform = new Bindable<Waveform>());
-        dependencies.CacheAs(actionStack = new EditorActionStack { NotificationManager = notifications });
+        dependencies.CacheAs(actionStack = new EditorActionStack(editorMap) { NotificationManager = notifications });
         dependencies.CacheAs(settings = new EditorSettings
         {
             ShowSamples = config.GetBindable<bool>(FluXisSetting.EditorShowSamples)

--- a/fluXis.Game/Screens/Edit/Tabs/Charting/ChartingContainer.cs
+++ b/fluXis.Game/Screens/Edit/Tabs/Charting/ChartingContainer.cs
@@ -227,7 +227,7 @@ public partial class ChartingContainer : EditorTabContainer, IKeyBindingHandler<
             Lane = lane
         };
 
-        actions.Add(new NotePlaceAction(note, Map));
+        actions.Add(new NotePlaceAction(note));
     }
 
     protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -344,7 +344,7 @@ public partial class ChartingContainer : EditorTabContainer, IKeyBindingHandler<
             hitObject.Time += (float)EditorClock.CurrentTime;
         }
 
-        actions.Add(new NotePasteAction(content.HitObjects.ToArray(), Map));
+        actions.Add(new NotePasteAction(content.HitObjects.ToArray()));
 
         notifications.SendSmallText($"Pasted {content.HitObjects.Count} hit objects.", FontAwesome6.Solid.Check);
     }

--- a/fluXis.Game/Screens/Edit/Tabs/Charting/Placement/NotePlacementBlueprint.cs
+++ b/fluXis.Game/Screens/Edit/Tabs/Charting/Placement/NotePlacementBlueprint.cs
@@ -29,6 +29,6 @@ public partial class NotePlacementBlueprint : PlacementBlueprint
             return;
 
         Hit.HitSound = chartingContainer.CurrentHitSound.Value;
-        Actions.Add(new NotePlaceAction(Hit, Map));
+        Actions.Add(new NotePlaceAction(Hit));
     }
 }

--- a/fluXis.Game/Screens/Edit/Tabs/Charting/Selection/SelectionHandler.cs
+++ b/fluXis.Game/Screens/Edit/Tabs/Charting/Selection/SelectionHandler.cs
@@ -134,9 +134,10 @@ public partial class SelectionHandler : Container, IHasContextMenu
             var hits = objs.OfType<HitObject>().ToArray();
 
             if (hits.Length > 0)
-                actions.Add(new NoteRemoveAction(hits, map));
+                actions.Add(new NoteRemoveAction(hits));
         }
 
+        // todo: maybe should move this one into the NoteRemoveAction?
         foreach (ITimedObject obj in objs)
         {
             switch (obj)

--- a/fluXis.Game/Screens/Edit/Tabs/Charting/Toolbox/ToolboxHitsoundButton.cs
+++ b/fluXis.Game/Screens/Edit/Tabs/Charting/Toolbox/ToolboxHitsoundButton.cs
@@ -93,7 +93,7 @@ public partial class ToolboxHitsoundButton : ToolboxButton
             return;
         }
 
-        actions.Add(new NoteHitsoundChangeAction(map, hits.ToArray(), sampleFormatted));
+        actions.Add(new NoteHitsoundChangeAction(hits.ToArray(), sampleFormatted));
         UpdateSelectionState();
     }
 


### PR DESCRIPTION
Guess it's OK to make the contribution, so I made one.

I speculate `EditorMap` is the area (or sendbox?) for deal with edit the property in the beatmap.
All edit action should make the  `EditorAction` and push into the `EditorActionStack`, `EditorActionStack` will handle the run(redo)/undo action.
If that so, only `EditorActionStack` need to know the `EditorMap`. Technically it will be the only way call the undo/redo method in the editor action.

Also, seems it's a little bit like `memento pattern`, and that's what lazer does not have in the Editor now. Is it OK to use this project as PoC to describe how do deal with undo/redo with better way?