### PR TITLE
Clamp shader parameters to correct range when changing shaders

### DIFF
--- a/fluXis.Game/Screens/Edit/Tabs/Design/Points/Entries/ShaderEntry.cs
+++ b/fluXis.Game/Screens/Edit/Tabs/Design/Points/Entries/ShaderEntry.cs
@@ -120,6 +120,12 @@ public partial class ShaderEntry : PointListEntry
                 {
                     RequestClose?.Invoke(); // until there is a way to refresh
                     shader.Type = value;
+                    shader.StartParameters.Strength = Math.Clamp(shader.StartParameters.Strength, 0, maxStrength);
+                    shader.StartParameters.Strength2 = Math.Clamp(shader.StartParameters.Strength2, 0, maxStrength);
+                    shader.StartParameters.Strength3 = Math.Clamp(shader.StartParameters.Strength3, 0, maxStrength);
+                    shader.EndParameters.Strength = Math.Clamp(shader.EndParameters.Strength, 0, maxStrength);
+                    shader.EndParameters.Strength2 = Math.Clamp(shader.EndParameters.Strength2, 0, maxStrength);
+                    shader.EndParameters.Strength3 = Math.Clamp(shader.EndParameters.Strength3, 0, maxStrength);
                     Map.Update(shader);
                     OpenSettings();
                 }

--- a/fluXis.Game/Screens/Edit/Tabs/Design/Points/Entries/ShaderEntry.cs
+++ b/fluXis.Game/Screens/Edit/Tabs/Design/Points/Entries/ShaderEntry.cs
@@ -121,11 +121,11 @@ public partial class ShaderEntry : PointListEntry
                     RequestClose?.Invoke(); // until there is a way to refresh
                     shader.Type = value;
                     shader.StartParameters.Strength = Math.Clamp(shader.StartParameters.Strength, 0, maxStrength);
-                    shader.StartParameters.Strength2 = Math.Clamp(shader.StartParameters.Strength2, 0, maxStrength);
-                    shader.StartParameters.Strength3 = Math.Clamp(shader.StartParameters.Strength3, 0, maxStrength);
+                    shader.StartParameters.Strength2 = Math.Clamp(shader.StartParameters.Strength2, 0, maxStrength2);
+                    shader.StartParameters.Strength3 = Math.Clamp(shader.StartParameters.Strength3, 0, maxStrength3);
                     shader.EndParameters.Strength = Math.Clamp(shader.EndParameters.Strength, 0, maxStrength);
-                    shader.EndParameters.Strength2 = Math.Clamp(shader.EndParameters.Strength2, 0, maxStrength);
-                    shader.EndParameters.Strength3 = Math.Clamp(shader.EndParameters.Strength3, 0, maxStrength);
+                    shader.EndParameters.Strength2 = Math.Clamp(shader.EndParameters.Strength2, 0, maxStrength2);
+                    shader.EndParameters.Strength3 = Math.Clamp(shader.EndParameters.Strength3, 0, maxStrength3);
                     Map.Update(shader);
                     OpenSettings();
                 }


### PR DESCRIPTION
previously, switching from a shader with high parameter values (chromatic) to another shader, the high parameter value was kept, resulting in too high values for that shader