### PR TITLE
Fix osu! parser on Linux

### DIFF
--- a/fluXis.Import.osu/OsuImport.cs
+++ b/fluXis.Import.osu/OsuImport.cs
@@ -139,7 +139,11 @@ public class OsuImport : MapImporter
 
     public static OsuMap ParseOsuMap(string fileContent, IEnumerable<string> files, bool eventsOnly = false)
     {
-        string[] lines = fileContent.Split(Environment.NewLine);
+        string[] lines = fileContent.Split(new[]
+        {
+            "\r\n",
+            "\n"
+        }, StringSplitOptions.None);
 
         OsuParser parser = new();
         OsuFileSection section = OsuFileSection.General;


### PR DESCRIPTION
`.osu` files use CRLF meanwhile `Environment.NewLine` on Linux is LF. This breaks the following
https://github.com/InventiveRhythm/fluXis/blob/f4769d50fd7d1b240b6ec9a23db4286171269d92/fluXis.Import.osu/OsuImport.cs#L172-L174
![image](https://github.com/user-attachments/assets/535cdf33-8903-4ed8-a6b4-1ebb3640a3b9)
