### PR TITLE
Minor QoL for mod select

### DIFF
--- a/fluXis/Graphics/UserInterface/FluXisSlider.cs
+++ b/fluXis/Graphics/UserInterface/FluXisSlider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using fluXis.Graphics.Sprites.Icons;
 using fluXis.Graphics.UserInterface.Color;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using Vector2 = osuTK.Vector2;
 
 namespace fluXis.Graphics.UserInterface;
@@ -23,6 +25,7 @@ public partial class FluXisSlider<T> : Container where T : struct, INumber<T>, I
     private BindableNumber<T> bindableNumber => Bindable as BindableNumber<T>;
     private ClickableSpriteIcon leftIcon;
     private ClickableSpriteIcon rightIcon;
+    private FluXisSliderBar sliderBar;
 
     private double lastSampleTime;
     private Sample valueChange;
@@ -52,7 +55,7 @@ public partial class FluXisSlider<T> : Container where T : struct, INumber<T>, I
             {
                 RelativeSizeAxes = Axes.Both,
                 Padding = new MarginPadding { Horizontal = 20 },
-                Child = new FluXisSliderBar(this, Height)
+                Child = sliderBar = new FluXisSliderBar(this, Height)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Current = Bindable,
@@ -115,8 +118,14 @@ public partial class FluXisSlider<T> : Container where T : struct, INumber<T>, I
         }
     }
 
+    public void OnDoubleClick(Action<DoubleClickEvent> onDoubleClick)
+    {
+        sliderBar.BindDoubleClick(onDoubleClick);
+    }
+
     private partial class FluXisSliderBar : SliderBar<T>
     {
+        private Action<DoubleClickEvent> onDoubleClickCallback;
         private FluXisSlider<T> parent { get; }
         private Box background { get; }
         private Box bar { get; }
@@ -155,6 +164,22 @@ public partial class FluXisSlider<T> : Container where T : struct, INumber<T>, I
             var colour = parent.CustomColor ?? FluXisColors.AccentGradient.Interpolate(new Vector2(value, 1));
             bar.FadeColour(colour, 400, Easing.OutQuint).ResizeWidthTo(value, 400, Easing.OutQuint);
             background.FadeColour(colour, 400, Easing.OutQuint);
+        }
+
+        public void BindDoubleClick(Action<DoubleClickEvent> onDoubleClick)
+        {
+            onDoubleClickCallback = onDoubleClick;
+        }
+
+        protected override bool OnDoubleClick(DoubleClickEvent e)
+        {
+            if (onDoubleClickCallback != null)
+            {
+                onDoubleClickCallback.Invoke(e);
+                return true;
+            }
+            
+            return base.OnDoubleClick(e);
         }
     }
 }

--- a/fluXis/Screens/Select/Mods/ModCategory.cs
+++ b/fluXis/Screens/Select/Mods/ModCategory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using fluXis.Graphics.Sprites.Text;
 using fluXis.Graphics.UserInterface.Color;
@@ -7,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Framework.Input.Events;
 using osuTK;
 
 namespace fluXis.Screens.Select.Mods;
@@ -111,5 +113,10 @@ public partial class ModCategory : CompositeDrawable
                     entry.Hide();
             }
         }, delay);
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        return true;
     }
 }

--- a/fluXis/Screens/Select/Mods/ModReset.cs
+++ b/fluXis/Screens/Select/Mods/ModReset.cs
@@ -1,0 +1,179 @@
+using System;
+using fluXis.Audio;
+using fluXis.Graphics.Sprites.Icons;
+using fluXis.Graphics.Sprites.Text;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Graphics.UserInterface.Interaction;
+using fluXis.Localization;
+using fluXis.Mods;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osuTK;
+
+namespace fluXis.Screens.Select.Mods;
+
+public partial class ModReset : CompositeDrawable, IMod
+{
+    public new string Name => "Reset";
+    public string Acronym => "RM";
+    public string Description => "Clear all selected mods.";
+    public IconUsage Icon => FontAwesome6.Solid.RotateLeft;
+    public ModType Type => ModType.Misc;
+    public float ScoreMultiplier => 1f;
+    public bool Rankable => true;
+    public Type[] IncompatibleMods => Array.Empty<Type>();
+
+    [Resolved]
+    private UISamples samples { get; set; }
+
+    private Container content { get; }
+    private Box background { get; }
+    private HoverLayer hover { get; }
+    private FlashLayer flash { get; }
+
+    private ModsOverlay overlay { get; set; }
+
+    private Box line { get; }
+    private FillFlowContainer flow { get; }
+    private SpriteIcon icon { get; }
+    private ForcedHeightText name { get; }
+    private ForcedHeightText description { get; }
+
+    public ModReset(ModsOverlay overlay)
+    {
+        this.overlay = overlay;
+
+        RelativeSizeAxes = Axes.X;
+        Width = 0.75f;
+        Height = 74;
+        AlwaysPresent = true;
+        Alpha = 0;
+
+        InternalChild = content = new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Shear = new Vector2(.2f, 0),
+            CornerRadius = 4,
+            Masking = true,
+            Children = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = FluXisColors.Background2
+                },
+                hover = new HoverLayer { Colour = Colour4.White },
+                line = new Box
+                {
+                    Width = 6,
+                    RelativeSizeAxes = Axes.Y,
+                    Colour = Colour4.White
+                },
+                flow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Horizontal,
+                    Padding = new MarginPadding { Horizontal = 20 },
+                    Spacing = new Vector2(12),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Shear = new Vector2(-.2f, 0),
+                    Children = new Drawable[]
+                    {
+                        icon = new FluXisSpriteIcon
+                        {
+                            Icon = FontAwesome6.Solid.RotateLeft,
+                            Size = new Vector2(20),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                        },
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(2),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Children = new Drawable[]
+                            {
+                                name = new ForcedHeightText
+                                {
+                                    Text = LocalizationStrings.Mods.GetName(this),
+                                    Height = 12,
+                                    TextColor = Colour4.White,
+                                    WebFontSize = 16,
+                                },
+                                description = new ForcedHeightText
+                                {
+                                    Text = LocalizationStrings.Mods.GetDescription(this),
+                                    Height = 8,
+                                    TextColor = Colour4.White,
+                                    WebFontSize = 12,
+                                    Alpha = .8f
+                                }
+                            }
+                        }
+                    }
+                },
+                flash = new FlashLayer { Colour = Colour4.White }
+            }
+        };
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        FinishTransforms(true);
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        samples.Click();
+        overlay.DeselectAll();
+
+        return true;
+    }
+
+    protected override bool OnHover(HoverEvent e)
+    {
+        hover.Show();
+        samples.Hover();
+        return true;
+    }
+
+    protected override void OnHoverLost(HoverLostEvent e)
+    {
+        hover.Hide();
+    }
+
+    public override void Show()
+    {
+        this.FadeIn(400);
+        content.MoveToX(50).MoveToX(0, 400, Easing.OutQuint);
+    }
+
+    public override void Hide()
+    {
+        this.FadeOut(200);
+        content.MoveToX(-50, 400, Easing.OutQuint);
+    }
+
+    public void Animate()
+    {
+        flash.Show();
+
+        icon.Colour = FluXisColors.Background2;
+        name.Colour = FluXisColors.Background2;
+        description.Colour = FluXisColors.Background2;
+
+        icon.Delay(100).FadeColour(Colour4.White, 250);
+        name.Delay(100).FadeColour(Colour4.White, 250);
+        description.Delay(100).FadeColour(Colour4.White, 250);
+    }
+}

--- a/fluXis/Screens/Select/Mods/ModSelectRate.cs
+++ b/fluXis/Screens/Select/Mods/ModSelectRate.cs
@@ -24,6 +24,7 @@ public partial class ModSelectRate : FillFlowContainer
     public ModsOverlay Selector { get; set; }
 
     public BindableFloat RateBindable { get; private set; }
+    private FluXisSlider<float> rateSlider { get; set; }
     private RateMod mod;
 
     private FluXisSpriteText rateText;
@@ -137,7 +138,7 @@ public partial class ModSelectRate : FillFlowContainer
                                     }
                                 }
                             },
-                            new FluXisSlider<float>
+                            rateSlider = new FluXisSlider<float>
                             {
                                 Bindable = RateBindable,
                                 RelativeSizeAxes = Axes.X,
@@ -181,6 +182,11 @@ public partial class ModSelectRate : FillFlowContainer
 
             int multiplier = (int)Math.Round(mod.ScoreMultiplier * 100) - 100;
             multiplierText.Text = $"{(multiplier > 0 ? "+" : string.Empty)}{multiplier}%";
+        });
+
+        rateSlider.OnDoubleClick(e =>
+        {
+            RateBindable.Value = 1f;
         });
     }
 

--- a/fluXis/Screens/Select/Mods/ModSelectRate.cs
+++ b/fluXis/Screens/Select/Mods/ModSelectRate.cs
@@ -12,6 +12,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osuTK;
 
 namespace fluXis.Screens.Select.Mods;
@@ -201,6 +202,11 @@ public partial class ModSelectRate : FillFlowContainer
     {
         this.Delay(ModsOverlay.STAGGER_DURATION)
             .FadeOut(200).MoveToX(-50, 400, Easing.OutQuint);
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        return true;
     }
 
     private partial class SliderTickMark : Container

--- a/fluXis/Screens/Select/Mods/ModsOverlay.cs
+++ b/fluXis/Screens/Select/Mods/ModsOverlay.cs
@@ -65,6 +65,7 @@ public partial class ModsOverlay : VisibilityContainer
     private ModCategory diffIncrease;
     private ModCategory miscellaneous;
     private ModCategory automation;
+    private ModReset modResetButton;
 
     private Sample sampleOpen;
     private Sample sampleClose;
@@ -258,9 +259,16 @@ public partial class ModsOverlay : VisibilityContainer
                                                                 new AutoPlayMod()
                                                             })
                                                         }
-                                                    }
+                                                    },
                                                 }
                                             }
+                                        },
+                                        new Container
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Margin = new MarginPadding { Top = 30 },
+                                            Child = modResetButton = new ModReset(this)
                                         }
                                     }
                                 }
@@ -290,6 +298,7 @@ public partial class ModsOverlay : VisibilityContainer
         diffIncrease.Show((diffDecrease.ModCount + 3) * STAGGER_DURATION);
         miscellaneous.Show((diffDecrease.ModCount + 3) * STAGGER_DURATION);
         automation.Show((diffDecrease.ModCount + diffIncrease.ModCount + 4) * STAGGER_DURATION);
+        modResetButton.Show();
         // this.TransformTo(nameof(blur), 1f, FluXisScreen.MOVE_DURATION, Easing.OutQuint);
 
         sampleOpen?.Play();
@@ -305,6 +314,7 @@ public partial class ModsOverlay : VisibilityContainer
         diffIncrease.Hide((diffDecrease.ModCount + 3) * STAGGER_DURATION);
         miscellaneous.Hide((diffDecrease.ModCount + 3) * STAGGER_DURATION);
         automation.Hide((diffDecrease.ModCount + diffIncrease.ModCount + 4) * STAGGER_DURATION);
+        modResetButton.Hide();
         // this.TransformTo(nameof(blur), 0f, FluXisScreen.MOVE_DURATION, Easing.OutQuint);
 
         if (!first)
@@ -333,6 +343,7 @@ public partial class ModsOverlay : VisibilityContainer
         sampleDeselect?.Play();
         SelectedMods.Clear();
         RateMod.RateBindable.Value = 1f;
+        modResetButton.Animate();
     }
 
     public void UpdateTotalMultiplier()


### PR DESCRIPTION
This really needs review

## Preview thing idk
https://github.com/user-attachments/assets/995637e6-a0fa-4ac1-b1d2-c69a0c4138dc

## Changes
- Double click slider to reset rate modifier
- Dedicated Button to Deselect all mods
- Clicking on categories doesn't close the mod menu

### Code Changes
I've added a double click binding in ``FluXisSlider.cs``
Also Added a new file ``ModReset.cs`` to ``Screens/Select/Mods``, I couldn't really inherit from ``ModEntry`` and override what's necessary (it was painful) so the implementation is similar.
Also added localization for Mod reset button wasn't sure if I should put the localization as a mod or in ``ModSelectStrings`` and have two fields one for name and description, so far I've settled on having it as a mod
```C#
// inherits from IMod
public new string Name => "Reset";
public string Acronym => "RM";
public string Description => "Clear all selected mods.";
public IconUsage Icon => FontAwesome6.Solid.RotateLeft;
public ModType Type => ModType.Misc;
public float ScoreMultiplier => 1f;
public bool Rankable => true;
public Type[] IncompatibleMods => Array.Empty<Type>();
```