### PR TITLE
Fix resetting Key bindings to their defaults

### DIFF
--- a/fluXis/Input/GameplayKeybindContainer.cs
+++ b/fluXis/Input/GameplayKeybindContainer.cs
@@ -41,10 +41,10 @@ public partial class GameplayKeybindContainer : RealmKeyBindingContainer<FluXisG
         else
             binds = Enum.GetValues<FluXisGameplayKeybind>().ToList();
 
-        return binds.Select(b => new KeyBinding(getDefaultFor(b), b));
+        return binds.Select(b => new KeyBinding(GetDefaultFor(b), b));
     }
 
-    private InputKey getDefaultFor(FluXisGameplayKeybind bind) => bind switch
+    public static InputKey GetDefaultFor(FluXisGameplayKeybind bind) => bind switch
     {
         FluXisGameplayKeybind.Key1k1 => InputKey.Space,
 

--- a/fluXis/Input/GlobalKeybindContainer.cs
+++ b/fluXis/Input/GlobalKeybindContainer.cs
@@ -27,7 +27,7 @@ public partial class GlobalKeybindContainer : RealmKeyBindingContainer<FluXisGlo
     public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
         .Concat(InGameKeyBindings);
 
-    public IEnumerable<KeyBinding> GlobalKeyBindings = new[]
+    public static IEnumerable<KeyBinding> GlobalKeyBindings = new[]
     {
         new KeyBinding(InputKey.Enter, FluXisGlobalKeybind.Select),
         new KeyBinding(InputKey.Escape, FluXisGlobalKeybind.Back),
@@ -59,7 +59,7 @@ public partial class GlobalKeybindContainer : RealmKeyBindingContainer<FluXisGlo
         new KeyBinding(new KeyCombination(InputKey.S, InputKey.E, InputKey.X), FluXisGlobalKeybind.Funny)
     };
 
-    public IEnumerable<KeyBinding> InGameKeyBindings = new[]
+    public static IEnumerable<KeyBinding> InGameKeyBindings = new[]
     {
         new KeyBinding(InputKey.Space, FluXisGlobalKeybind.Skip),
         new KeyBinding(InputKey.Shift, FluXisGlobalKeybind.QuickRestart),

--- a/fluXis/Input/GlobalKeybindContainer.cs
+++ b/fluXis/Input/GlobalKeybindContainer.cs
@@ -27,7 +27,7 @@ public partial class GlobalKeybindContainer : RealmKeyBindingContainer<FluXisGlo
     public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
         .Concat(InGameKeyBindings);
 
-    public static IEnumerable<KeyBinding> GlobalKeyBindings = new[]
+    public static IEnumerable<KeyBinding> GlobalKeyBindings { get; } = new[]
     {
         new KeyBinding(InputKey.Enter, FluXisGlobalKeybind.Select),
         new KeyBinding(InputKey.Escape, FluXisGlobalKeybind.Back),
@@ -59,7 +59,7 @@ public partial class GlobalKeybindContainer : RealmKeyBindingContainer<FluXisGlo
         new KeyBinding(new KeyCombination(InputKey.S, InputKey.E, InputKey.X), FluXisGlobalKeybind.Funny)
     };
 
-    public static IEnumerable<KeyBinding> InGameKeyBindings = new[]
+    public static IEnumerable<KeyBinding> InGameKeyBindings { get; } = new[]
     {
         new KeyBinding(InputKey.Space, FluXisGlobalKeybind.Skip),
         new KeyBinding(InputKey.Shift, FluXisGlobalKeybind.QuickRestart),

--- a/fluXis/Overlay/Settings/UI/Keybind/SettingsAbstractKeybind.cs
+++ b/fluXis/Overlay/Settings/UI/Keybind/SettingsAbstractKeybind.cs
@@ -39,7 +39,7 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
     {
         get
         {
-            if (cachedIsDefault.IsNotNull()) return cachedIsDefault.Value;
+            if (cachedIsDefault != null) return cachedIsDefault.Value;
 
             KeyBinding[] defaultBindings = Keybinds.Select(InputUtils.GetDefaultBindingFor<T>).ToArray();
             KeyBinding[] keybindCombos = Keybinds.Select(GetComboFor).ToArray();
@@ -56,11 +56,6 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
             cachedIsDefault = true;
             return true;
         }
-    }
-
-    private void clearIsDefaultCache()
-    {
-        cachedIsDefault = null;
     }
 
     protected SettingsAbstractKeybind()
@@ -94,7 +89,6 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
                 KeybindText = keyCombinationProvider.GetReadableString(GetComboFor(keybind).KeyCombination)
             });
         }
-        UpdateResetButton();
     }
 
     protected override void Reset()
@@ -186,7 +180,6 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
             UpdateBinding(keybind, combination);
             
             clearIsDefaultCache();
-            UpdateResetButton();
 
             var bind = GetComboFor(keybind);
             flow[index].KeybindText = keyCombinationProvider.GetReadableString(bind.KeyCombination);
@@ -195,6 +188,11 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
             menuScroll?.Play();
         }
         else index = -1;
+    }
+
+    private void clearIsDefaultCache()
+    {
+        cachedIsDefault = null;
     }
 
     private void select(T bind)

--- a/fluXis/Overlay/Settings/UI/Keybind/SettingsAbstractKeybind.cs
+++ b/fluXis/Overlay/Settings/UI/Keybind/SettingsAbstractKeybind.cs
@@ -15,7 +15,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osuTK;
 using osuTK.Input;
-using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Logging;
 
 namespace fluXis.Overlay.Settings.UI.Keybind;
 
@@ -41,18 +41,25 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
         {
             if (cachedIsDefault != null) return cachedIsDefault.Value;
 
-            KeyBinding[] defaultBindings = Keybinds.Select(InputUtils.GetDefaultBindingFor<T>).ToArray();
-            KeyBinding[] keybindCombos = Keybinds.Select(GetComboFor).ToArray();
-
-            foreach (var (keybind, defaultBinding) in keybindCombos.Zip(defaultBindings))
+            try
             {
-                if (!defaultBinding.KeyCombination.Keys.SequenceEqual(keybind.KeyCombination.Keys))
+                KeyBinding[] defaultBindings = Keybinds.Select(InputUtils.GetDefaultBindingFor<T>).ToArray();
+                KeyBinding[] keybindCombos = Keybinds.Select(GetComboFor).ToArray();
+
+                foreach (var (keybind, defaultBinding) in keybindCombos.Zip(defaultBindings))
                 {
-                    cachedIsDefault = false;
-                    return false;
+                    if (!defaultBinding.KeyCombination.Keys.SequenceEqual(keybind.KeyCombination.Keys))
+                    {
+                        cachedIsDefault = false;
+                        return false;
+                    }
                 }
             }
-            
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed get default bindings for settings");
+            }
+
             cachedIsDefault = true;
             return true;
         }

--- a/fluXis/Overlay/Settings/UI/Keybind/SettingsAbstractKeybind.cs
+++ b/fluXis/Overlay/Settings/UI/Keybind/SettingsAbstractKeybind.cs
@@ -96,6 +96,8 @@ public abstract partial class SettingsAbstractKeybind<T> : SettingsItem
                 KeybindText = keyCombinationProvider.GetReadableString(GetComboFor(keybind).KeyCombination)
             });
         }
+
+        base.UpdateResetButton();
     }
 
     protected override void Reset()

--- a/fluXis/Overlay/Settings/UI/SettingsItem.cs
+++ b/fluXis/Overlay/Settings/UI/SettingsItem.cs
@@ -88,7 +88,7 @@ public abstract partial class SettingsItem : Container
     protected override void LoadComplete()
     {
         base.LoadComplete();
-        UpdateResetButton();
+        updateResetButton();
 
         Content.FinishTransforms(true);
 
@@ -106,10 +106,10 @@ public abstract partial class SettingsItem : Container
         if (isDefault == IsDefault) return;
 
         isDefault = IsDefault;
-        UpdateResetButton();
+        updateResetButton();
     }
 
-    protected void UpdateResetButton()
+    private void updateResetButton()
     {
         if (IsDefault)
             resetButton.Hide();

--- a/fluXis/Overlay/Settings/UI/SettingsItem.cs
+++ b/fluXis/Overlay/Settings/UI/SettingsItem.cs
@@ -88,7 +88,7 @@ public abstract partial class SettingsItem : Container
     protected override void LoadComplete()
     {
         base.LoadComplete();
-        updateResetButton();
+        UpdateResetButton();
 
         Content.FinishTransforms(true);
 
@@ -106,10 +106,10 @@ public abstract partial class SettingsItem : Container
         if (isDefault == IsDefault) return;
 
         isDefault = IsDefault;
-        updateResetButton();
+        UpdateResetButton();
     }
 
-    private void updateResetButton()
+    protected void UpdateResetButton()
     {
         if (IsDefault)
             resetButton.Hide();

--- a/fluXis/Screens/Edit/Input/EditorKeybindingContainer.cs
+++ b/fluXis/Screens/Edit/Input/EditorKeybindingContainer.cs
@@ -34,7 +34,9 @@ public partial class EditorKeybindingContainer : KeyBindingContainer<EditorKeybi
         loadKeymap();
     }
 
-    public override IEnumerable<IKeyBinding> DefaultKeyBindings => new KeyBinding[]
+    public override IEnumerable<IKeyBinding> DefaultKeyBindings => EditorKeyBindings;
+
+    public static IEnumerable<KeyBinding> EditorKeyBindings { get; } = new KeyBinding[]
     {
         new(new KeyCombination(InputKey.F1), EditorKeybinding.OpenHelp),
         new(new KeyCombination(InputKey.Control, InputKey.S), EditorKeybinding.Save),

--- a/fluXis/Utils/InputUtils.cs
+++ b/fluXis/Utils/InputUtils.cs
@@ -14,11 +14,32 @@ public static class InputUtils
 
     public static KeyBinding GetBindingFor(string bind, FluXisRealm realm)
     {
-        var keybind = realm.Run(r => r.All<RealmKeybind>().FirstOrDefault(k => k.Action == bind).Detach());
+        var keybind = realm.Run(r => r.All<RealmKeybind>().FirstOrDefault(k => k.Action == bind)?.Detach());
         if (keybind == null) return null;
 
         return keybind.Key.Contains(',')
             ? new KeyBinding(keybind.Key.Split(',').Select(Enum.Parse<InputKey>).ToArray(), bind)
             : new KeyBinding(Enum.Parse<InputKey>(keybind.Key), bind);
+    }
+
+    // using a string as an arg is painful for this, It's best to just use the types
+    public static KeyBinding GetDefaultBindingFor<T>(T bind) where T : Enum
+    {
+        if (bind is FluXisGlobalKeybind globalBind)
+        {
+            var globalKeyBind = GlobalKeybindContainer.GlobalKeyBindings
+                .Concat(GlobalKeybindContainer.InGameKeyBindings)
+                .FirstOrDefault(kb => kb.Action.Equals(globalBind));
+
+            return globalKeyBind;
+        }
+
+        if (bind is FluXisGameplayKeybind gameplayBind)
+        {
+            var defaultKey = GameplayKeybindContainer.GetDefaultFor(gameplayBind);
+            return new KeyBinding(defaultKey, gameplayBind);
+        }
+
+        return null;
     }
 }

--- a/fluXis/Utils/InputUtils.cs
+++ b/fluXis/Utils/InputUtils.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using fluXis.Database;
 using fluXis.Database.Input;
 using fluXis.Input;
+using fluXis.Screens.Edit.Input;
 using osu.Framework.Input.Bindings;
 
 namespace fluXis.Utils;
@@ -34,12 +35,20 @@ public static class InputUtils
             return globalKeyBind;
         }
 
+        if (bind is EditorKeybinding editorBind)
+        {
+            var editorKeybind = EditorKeybindingContainer.EditorKeyBindings
+                .FirstOrDefault(kb => kb.Action.Equals(editorBind));
+
+            return editorKeybind;
+        }
+
         if (bind is FluXisGameplayKeybind gameplayBind)
         {
             var defaultKey = GameplayKeybindContainer.GetDefaultFor(gameplayBind);
             return new KeyBinding(defaultKey, gameplayBind);
         }
 
-        return null;
+        throw new ArgumentException($"keybinding type not found for: {typeof(T).Name}", nameof(bind));
     }
 }


### PR DESCRIPTION
# Fix for #139 

### Before:

https://github.com/user-attachments/assets/4e06f896-ff83-47de-a81b-14e78eb1dd67

### After:

https://github.com/user-attachments/assets/20e12b0d-49c6-4ef8-b73d-91be98d8a1b1

## Code Changes
Changes here for this are really debatable

First, inside ``GameplayKeybindContainer.cs`` I've changed the visibility of ``GetDefaultFor`` from ``private`` to ``public static`` and in ``GlobalKeybindContainer.cs`` changed the lifetime of  ``GlobalKeyBindings`` and ``InGameKeyBindings`` to ``static``
Reason for that being in ``InputUtils.cs`` I've created a new helper method ``GetDefaultBindingFor`` and as far as I've tested there has been no issues with these changes.

in ``SettingItem.cs`` only changed visibility of ``UpdateResetButton`` to ``protected`` to be able to use it normally in ``SettingsAbstractKeybind.cs`` Because in the original the reset button wasn't visible because it wasn't implemented (reset button wasn't being updated and ``UpdateResetButton`` is also responsible for hiding and showing the Drawable).

and finally the rest of the implementation in ``SettingsAbstractKeybind.cs``, added logic to get the default keys and reset, Since ``IsDefault`` keeps on updating this really slows down and lags the game a lot with how on every time we get the keybinds
so I've added a simple "cache" which if the user didn't change any binding we will not need to get the keybindings