### PR TITLE
Fix receptor offset not changing during lane switches

### DIFF
--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/HitObjectManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/HitObjectManager.cs
@@ -52,6 +52,7 @@ public partial class HitObjectManager : Container<HitObjectColumn>
     public int KeyCount => playfield.RealmMap.KeyCount;
 
     public float HitPosition => DrawHeight - laneSwitchManager.HitPosition;
+    public float ReceptorOffset => DrawHeight - laneSwitchManager.ReceptorOffset;
 
     public bool Finished { get; private set; }
 

--- a/fluXis/Screens/Gameplay/Ruleset/LaneSwitchManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/LaneSwitchManager.cs
@@ -27,21 +27,7 @@ public partial class LaneSwitchManager : CompositeComponent
     public LaneSwitchEvent Current { get; private set; }
     public int CurrentCount { get; private set; }
     public float HitPosition { get; private set; }
-    private float receptorOffset;
-    public float ReceptorOffset 
-    { 
-        get => receptorOffset;
-        private set
-        {
-            if (receptorOffset != value)
-            {
-                receptorOffset = value;
-                ReceptorOffsetChanged?.Invoke(value);
-            }
-        }
-    }
-    
-    public event Action<float> ReceptorOffsetChanged;
+    public float ReceptorOffset { get; private set; }
 
     public LaneSwitchManager(List<LaneSwitchEvent> events, int keycount, bool newLayout, bool mirror)
     {

--- a/fluXis/Screens/Gameplay/Ruleset/LaneSwitchManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/LaneSwitchManager.cs
@@ -27,7 +27,21 @@ public partial class LaneSwitchManager : CompositeComponent
     public LaneSwitchEvent Current { get; private set; }
     public int CurrentCount { get; private set; }
     public float HitPosition { get; private set; }
-    public float ReceptorOffset { get; private set; }
+    private float receptorOffset;
+    public float ReceptorOffset 
+    { 
+        get => receptorOffset;
+        private set
+        {
+            if (receptorOffset != value)
+            {
+                receptorOffset = value;
+                ReceptorOffsetChanged?.Invoke(value);
+            }
+        }
+    }
+    
+    public event Action<float> ReceptorOffsetChanged;
 
     public LaneSwitchManager(List<LaneSwitchEvent> events, int keycount, bool newLayout, bool mirror)
     {

--- a/fluXis/Screens/Gameplay/Ruleset/LaneSwitchManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/LaneSwitchManager.cs
@@ -27,6 +27,7 @@ public partial class LaneSwitchManager : CompositeComponent
     public LaneSwitchEvent Current { get; private set; }
     public int CurrentCount { get; private set; }
     public float HitPosition { get; private set; }
+    public float ReceptorOffset { get; private set; }
 
     public LaneSwitchManager(List<LaneSwitchEvent> events, int keycount, bool newLayout, bool mirror)
     {
@@ -56,6 +57,7 @@ public partial class LaneSwitchManager : CompositeComponent
 
         CurrentCount = keycount;
         HitPosition = skin.SkinJson.GetKeymode(keycount).HitPosition;
+        ReceptorOffset = skin.SkinJson.GetKeymode(keycount).ReceptorOffset;
 
         for (int i = 0; i < keycount; i++)
         {
@@ -77,11 +79,13 @@ public partial class LaneSwitchManager : CompositeComponent
             {
                 var count = Math.Max(1, ls.Count);
                 var pos = (float)skin.SkinJson.GetKeymode(count).HitPosition;
+                var rOffset = (float)skin.SkinJson.GetKeymode(count).ReceptorOffset;
 
                 if (first)
                 {
                     CurrentCount = count;
                     HitPosition = pos;
+                    ReceptorOffset = rOffset;
                 }
 
                 var dur = Math.Max(ls.Duration, 0);
@@ -98,6 +102,7 @@ public partial class LaneSwitchManager : CompositeComponent
                 }
 
                 this.TransformTo(nameof(HitPosition), pos, dur, ls.Easing);
+                this.TransformTo(nameof(ReceptorOffset), rOffset, dur, ls.Easing);
                 this.TransformTo(nameof(CurrentCount), count).OnComplete(_ => Current = ls);
             }
 

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -14,6 +14,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace fluXis.Screens.Gameplay.Ruleset.Playfields;
@@ -145,19 +146,14 @@ public partial class Playfield : Container
         MapEvents.TimeOffsetEvents.ForEach(e => e.Apply(HitManager));
     }
 
-    protected override void LoadComplete()
-    {
-        base.LoadComplete();
-
-        laneSwitchManager.ReceptorOffsetChanged += offset =>
-            Receptors.Padding = Receptors.Padding with { Bottom = offset };
-    }
-
     protected override void Update()
     {
         updatePositionScale();
+        var newReceptorOffset = laneSwitchManager.ReceptorOffset;
 
         hitline.Y = -laneSwitchManager.HitPosition;
+        if (!Precision.AlmostEquals(newReceptorOffset, Receptors.Padding.Bottom))
+            Receptors.Padding = Receptors.Padding with { Bottom = newReceptorOffset };
 
         topCover.Y = (topCoverHeight.Value - 1f) / 2f;
         bottomCover.Y = (1f - bottomCoverHeight.Value) / 2f;

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -150,9 +150,7 @@ public partial class Playfield : Container
         base.LoadComplete();
 
         laneSwitchManager.ReceptorOffsetChanged += offset =>
-        {
-            Receptors.Padding = new MarginPadding { Bottom = offset };
-        };
+            Receptors.Padding = Receptors.Padding with { Bottom = offset };
     }
 
     protected override void Update()

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -145,12 +145,21 @@ public partial class Playfield : Container
         MapEvents.TimeOffsetEvents.ForEach(e => e.Apply(HitManager));
     }
 
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        laneSwitchManager.ReceptorOffsetChanged += offset =>
+        {
+            Receptors.Padding = new MarginPadding { Bottom = offset };
+        };
+    }
+
     protected override void Update()
     {
         updatePositionScale();
 
         hitline.Y = -laneSwitchManager.HitPosition;
-        Receptors.Padding = new MarginPadding { Bottom = laneSwitchManager.ReceptorOffset };
 
         topCover.Y = (topCoverHeight.Value - 1f) / 2f;
         bottomCover.Y = (1f - bottomCoverHeight.Value) / 2f;

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -150,6 +150,7 @@ public partial class Playfield : Container
         updatePositionScale();
 
         hitline.Y = -laneSwitchManager.HitPosition;
+        Receptors.Padding = new MarginPadding { Bottom = laneSwitchManager.ReceptorOffset };
 
         topCover.Y = (topCoverHeight.Value - 1f) / 2f;
         bottomCover.Y = (1f - bottomCoverHeight.Value) / 2f;


### PR DESCRIPTION
### Fix for #137 
using Kori's skin

## Before:

https://github.com/user-attachments/assets/82129d8a-a0fb-49d4-a58a-f625500d0589


## After:

https://github.com/user-attachments/assets/82237a63-9a08-420a-89ec-1b86674ca274

Closes #137 

