### PR TITLE
Editor timeline optimization

### DIFF
--- a/fluXis/Audio/Transforms/TransformableClock.cs
+++ b/fluXis/Audio/Transforms/TransformableClock.cs
@@ -3,6 +3,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Timing;
+using osu.Framework.Utils;
 
 namespace fluXis.Audio.Transforms;
 
@@ -37,5 +38,7 @@ public abstract partial class TransformableClock : CompositeComponent, IAdjustab
     public TransformSequence<TransformableClock> TimeTo(double newTime, double duration = 0, Easing easing = Easing.None)
         => this.TransformTo(this.PopulateTransform(new TimeTransform(), newTime, duration, easing));
 
+    public double InterpolateAt(double elapsedTime, double newTime, double duration, Easing easing = Easing.None)
+        => Interpolation.ValueAt(elapsedTime, CurrentTime, newTime, 0, duration, easing);
     public abstract void ProcessFrame();
 }

--- a/fluXis/Audio/Transforms/TransformableClock.cs
+++ b/fluXis/Audio/Transforms/TransformableClock.cs
@@ -40,5 +40,6 @@ public abstract partial class TransformableClock : CompositeComponent, IAdjustab
 
     public double InterpolateAt(double elapsedTime, double newTime, double duration, Easing easing = Easing.None)
         => Interpolation.ValueAt(elapsedTime, CurrentTime, newTime, 0, duration, easing);
+
     public abstract void ProcessFrame();
 }

--- a/fluXis/Screens/Edit/EditorClock.cs
+++ b/fluXis/Screens/Edit/EditorClock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Linq;
 using fluXis.Audio;
 using fluXis.Audio.Transforms;
@@ -31,12 +32,19 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
     public override bool IsRunning => underlying.IsRunning;
     double IClock.Rate => underlying.Rate;
 
-    public double CurrentTimeAccurate => Transforms.OfType<TimeTransform>().FirstOrDefault()?.EndValue ?? CurrentTime;
+    //public double CurrentTimeAccurate => Transforms.OfType<TimeTransform>().FirstOrDefault()?.EndValue ?? CurrentTime;
+    public double CurrentTimeAccurate => isSeekingSmoothly? smoothSeekTarget : CurrentTime;
 
     private readonly FramedMapClock underlying;
     private readonly Bindable<DrawableTrack> track = new();
 
     private bool playbackFinished;
+
+    //seeking animation variables
+    private double interpolationDuration = 300;
+    private bool isSeekingSmoothly = false;
+    private double smoothSeekTarget;
+    private double smoothSeekTime;
 
     public EditorClock(MapInfo mapInfo)
     {
@@ -58,9 +66,28 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
         if (IsRunning)
             Seek(time);
         else
-            TimeTo(time, 300, Easing.OutQuint);
+            startSeekAnimation(time, 300);
     }
 
+    private void startSeekAnimation(double newTime, double duration)
+    {
+        isSeekingSmoothly = true;
+        smoothSeekTime = 0;
+        smoothSeekTarget = newTime;
+        interpolationDuration = duration;
+    }
+    private void seekSmoothlyStep()
+    {
+        smoothSeekTime += Clock.ElapsedFrameTime;
+        if (smoothSeekTime > interpolationDuration)
+        {
+            isSeekingSmoothly = false;
+            smoothSeekTime = interpolationDuration;
+            Seek(smoothSeekTarget);
+        }
+        else
+            Seek(InterpolateAt(smoothSeekTime, smoothSeekTarget, interpolationDuration, Easing.OutQuint));
+    }
     private double snap(double position)
     {
         var point = MapInfo.GetTimingPoint((float)position);
@@ -164,6 +191,8 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
             if (IsRunning) underlying.Stop();
             if (CurrentTime > TrackLength) underlying.Seek(TrackLength);
         }
+
+        if (isSeekingSmoothly) seekSmoothlyStep();
 
         updateStep();
     }

--- a/fluXis/Screens/Edit/EditorClock.cs
+++ b/fluXis/Screens/Edit/EditorClock.cs
@@ -78,6 +78,11 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
     }
     private void seekSmoothlyStep()
     {
+        if (IsRunning)
+        {
+            isSeekingSmoothly = false;
+            return;
+        }
         smoothSeekTime += Clock.ElapsedFrameTime;
         if (smoothSeekTime > interpolationDuration)
         {

--- a/fluXis/Screens/Edit/EditorClock.cs
+++ b/fluXis/Screens/Edit/EditorClock.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Linq;
 using fluXis.Audio;
 using fluXis.Audio.Transforms;
@@ -31,9 +30,7 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
     public IClock Source => underlying.Source;
     public override bool IsRunning => underlying.IsRunning;
     double IClock.Rate => underlying.Rate;
-
-    //public double CurrentTimeAccurate => Transforms.OfType<TimeTransform>().FirstOrDefault()?.EndValue ?? CurrentTime;
-    public double CurrentTimeAccurate => isSeekingSmoothly? smoothSeekTarget : CurrentTime;
+    public double CurrentTimeAccurate => isSeekingSmoothly ? smoothSeekTarget : CurrentTime;
 
     private readonly FramedMapClock underlying;
     private readonly Bindable<DrawableTrack> track = new();

--- a/fluXis/Screens/Edit/EditorClock.cs
+++ b/fluXis/Screens/Edit/EditorClock.cs
@@ -73,6 +73,7 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
         smoothSeekTarget = newTime;
         interpolationDuration = duration;
     }
+    
     private void seekSmoothlyStep()
     {
         if (IsRunning)
@@ -80,7 +81,9 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
             isSeekingSmoothly = false;
             return;
         }
+        
         smoothSeekTime += Clock.ElapsedFrameTime;
+        
         if (smoothSeekTime > interpolationDuration)
         {
             isSeekingSmoothly = false;
@@ -90,6 +93,7 @@ public partial class EditorClock : TransformableClock, IFrameBasedClock, ISource
         else
             Seek(InterpolateAt(smoothSeekTime, smoothSeekTarget, interpolationDuration, Easing.OutQuint));
     }
+    
     private double snap(double position)
     {
         var point = MapInfo.GetTimingPoint((float)position);

--- a/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
@@ -50,6 +50,7 @@ public abstract partial class EditorTimingLines<T> : Container<T>
     protected override void Update()
     {
         bool shouldSort = false;
+
         while (pastLines.Count > 0 && !pastLines[^1].BelowScreen)
         {
             var line = pastLines[^1];
@@ -82,12 +83,6 @@ public abstract partial class EditorTimingLines<T> : Container<T>
 
         if (shouldSort)
             SortInternal();
-    }
-
-    private void addAndSort(T line)
-    {
-        Add(line);
-        SortInternal();
     }
 
     protected override int Compare(Drawable x, Drawable y)

--- a/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using fluXis.Graphics.UserInterface.Color;
 using fluXis.Map.Structures;

--- a/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using fluXis.Graphics.UserInterface.Color;
 using fluXis.Map.Structures;
@@ -51,14 +52,14 @@ public abstract partial class EditorTimingLines<T> : Container<T>
         while (pastLines.Count > 0 && !pastLines[^1].BelowScreen)
         {
             var line = pastLines[^1];
-            addAndSort(line);
+            Add(line);
             pastLines.Remove(line);
         }
 
         while (futureLines.Count > 0 && !futureLines[0].AboveScreen)
         {
             var line = futureLines[0];
-            addAndSort(line);
+            Add(line);
             futureLines.Remove(line);
         }
 
@@ -75,6 +76,8 @@ public abstract partial class EditorTimingLines<T> : Container<T>
             futureLines.Insert(0, line);
             Remove(line, false);
         }
+
+        SortInternal();
     }
 
     private void addAndSort(T line)

--- a/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
@@ -49,18 +49,21 @@ public abstract partial class EditorTimingLines<T> : Container<T>
 
     protected override void Update()
     {
+        bool shouldSort = false;
         while (pastLines.Count > 0 && !pastLines[^1].BelowScreen)
         {
             var line = pastLines[^1];
+            pastLines.RemoveAt(pastLines.Count - 1);
             Add(line);
-            pastLines.Remove(line);
+            shouldSort = true;
         }
 
         while (futureLines.Count > 0 && !futureLines[0].AboveScreen)
         {
             var line = futureLines[0];
+            futureLines.RemoveAt(0);
             Add(line);
-            futureLines.Remove(line);
+            shouldSort = true;
         }
 
         while (Children.Count > 0 && Children[0].BelowScreen)
@@ -77,7 +80,8 @@ public abstract partial class EditorTimingLines<T> : Container<T>
             Remove(line, false);
         }
 
-        SortInternal();
+        if (shouldSort)
+            SortInternal();
     }
 
     private void addAndSort(T line)


### PR DESCRIPTION
- Got rid of tween stacking while dragging the timeline handle
#26 
- Jumping over a long section in the charting editor tab no longer freezes the game, as the timing lines sorting was optimized.

https://github.com/user-attachments/assets/677e39d2-7ecd-410d-8a70-8b37fcf1ba27