### PR TITLE
Fix replay rate still being applied even after exiting Gameplay Screen

### DIFF
--- a/fluXis/Screens/Gameplay/GameplayScreen.cs
+++ b/fluXis/Screens/Gameplay/GameplayScreen.cs
@@ -556,7 +556,7 @@ public partial class GameplayScreen : FluXisScreen, IKeyBindingHandler<FluXisGlo
             ScheduleAfterChildren(() =>
             {
                 globalClock.Seek(GameplayClock.CurrentTime);
-                globalClock.RateTo(Rate, MOVE_DURATION, Easing.InQuint);
+                globalClock.RateTo(globalClock.Rate, MOVE_DURATION, Easing.InQuint);
             });
         }
 


### PR DESCRIPTION
## Before:

https://github.com/user-attachments/assets/06c5379c-ef68-4a1f-887e-fe737e7b4f22


## After:

https://github.com/user-attachments/assets/be6192ce-528d-49a4-8565-f69f69905b77

As you see here in the old one my rate is set to 0.5x but after exiting replay it's still 2x even though we have it at 0.5x.
Now the Rate is correctly applied after exiting.

<sub><sub>This small fix took longer than I'd like to admit...</sub></sub>