### PR TITLE
Scroll Multiplier QoL for editor

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Charting/Playfield/Tags/TimingTagContainer.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Playfield/Tags/TimingTagContainer.cs
@@ -1,4 +1,5 @@
 using fluXis.Map.Structures;
+using fluXis.Map.Structures.Events;
 using fluXis.Screens.Edit.Tabs.Charting.Playfield.Tags.TimingTags;
 
 namespace fluXis.Screens.Edit.Tabs.Charting.Playfield.Tags;
@@ -15,12 +16,18 @@ public partial class TimingTagContainer : EditorTagContainer
         foreach (var sv in Map.MapInfo.ScrollVelocities)
             addScrollVelocity(sv);
 
+        foreach (var sm in Map.MapInfo.MapEvents.ScrollMultiplyEvents)
+            addScrollMultiplier(sm);
+
         Map.TimingPointAdded += addTimingPoint;
         Map.TimingPointRemoved += RemoveTag;
         Map.ScrollVelocityAdded += addScrollVelocity;
         Map.ScrollVelocityRemoved += RemoveTag;
+        Map.ScrollMultiplierEventAdded += addScrollMultiplier;
+        Map.ScrollMultiplierEventRemoved += RemoveTag;
     }
 
     private void addTimingPoint(TimingPoint tp) => AddTag(new TimingPointTag(this, tp));
     private void addScrollVelocity(ScrollVelocity sv) => AddTag(new ScrollVelocityTag(this, sv));
+    private void addScrollMultiplier(ScrollMultiplierEvent sm) => AddTag(new ScrollMultiplierTag(this, sm));
 }

--- a/fluXis/Screens/Edit/Tabs/Charting/Playfield/Tags/TimingTags/ScrollMultiplierTag.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Playfield/Tags/TimingTags/ScrollMultiplierTag.cs
@@ -1,0 +1,37 @@
+using System;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Map.Structures.Events;
+using fluXis.Screens.Edit.Tabs.Shared.Points;
+using fluXis.Utils;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+
+namespace fluXis.Screens.Edit.Tabs.Charting.Playfield.Tags.TimingTags;
+
+public partial class ScrollMultiplierTag : EditorTag
+{
+    public override Colour4 TagColour => Theme.ScrollMultiply;
+
+    [Resolved]
+    private PointsSidebar points { get; set; }
+
+    public ScrollMultiplierEvent ScrollMultiplier => (ScrollMultiplierEvent)TimedObject;
+
+    public ScrollMultiplierTag(EditorTagContainer parent, ScrollMultiplierEvent sm)
+        : base(parent, sm)
+    {
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+        Text.Text = $"{ScrollMultiplier.Multiplier.ToStringInvariant("0.####")}x {Math.Floor(ScrollMultiplier.Duration)}ms";
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        points.ShowPoint(ScrollMultiplier);
+        return true;
+    }
+}

--- a/fluXis/Screens/Edit/Tabs/Charting/Playfield/Tags/TimingTags/ScrollMultiplierTag.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Playfield/Tags/TimingTags/ScrollMultiplierTag.cs
@@ -18,15 +18,44 @@ public partial class ScrollMultiplierTag : EditorTag
 
     public ScrollMultiplierEvent ScrollMultiplier => (ScrollMultiplierEvent)TimedObject;
 
+    private bool isHovered;
+    private MarginPadding originalPadding;
+    private MarginPadding expandedPadding;
+
     public ScrollMultiplierTag(EditorTagContainer parent, ScrollMultiplierEvent sm)
         : base(parent, sm)
     {
     }
 
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        originalPadding = Padding;
+        expandedPadding = originalPadding with { Left = originalPadding.Left + 4, Right = originalPadding.Right + 4 };
+    }
+
     protected override void Update()
     {
         base.Update();
-        Text.Text = $"{ScrollMultiplier.Multiplier.ToStringInvariant("0.####")}x {Math.Floor(ScrollMultiplier.Duration)}ms";
+        
+        if (isHovered)
+            Text.Text = $"{ScrollMultiplier.Multiplier.ToStringInvariant("0.####")}x {Math.Floor(ScrollMultiplier.Duration)}ms | {ScrollMultiplier.Easing}";
+        else
+            Text.Text = $"{ScrollMultiplier.Multiplier.ToStringInvariant("0.####")}x {Math.Floor(ScrollMultiplier.Duration)}ms";
+    }
+
+    protected override bool OnHover(HoverEvent e)
+    {
+        isHovered = true;
+        this.TransformTo(nameof(Padding), expandedPadding, 200, Easing.OutQuart);
+        return base.OnHover(e);
+    }
+
+    protected override void OnHoverLost(HoverLostEvent e)
+    {
+        isHovered = false;
+        this.TransformTo(nameof(Padding), originalPadding, 200, Easing.OutQuart);
+        base.OnHoverLost(e);
     }
 
     protected override bool OnClick(ClickEvent e)

--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ScrollMultiplierEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ScrollMultiplierEntry.cs
@@ -32,7 +32,7 @@ public partial class ScrollMultiplierEntry : PointListEntry
         {
             new FluXisSpriteText
             {
-                Text = $"{scroll.Multiplier.ToStringInvariant("0.##")}x {(int)scroll.Duration}ms",
+                Text = $"{scroll.Multiplier.ToStringInvariant("0.##")}x {(int)scroll.Duration}ms {scroll.Easing}",
                 Colour = Color
             }
         };


### PR DESCRIPTION
<img width="243" height="580" alt="image" src="https://github.com/user-attachments/assets/eb54ad1e-296d-46e8-9d8a-e0374d29f428" />

scroll multiplier tags

---

<img width="754" height="165" alt="image" src="https://github.com/user-attachments/assets/d7c897be-8f50-45eb-a16b-0df7da3b6157" />

better stacking

---

<img width="266" height="92" alt="{0AF9AA6C-3511-4BFA-B777-78BB43B662D2}" src="https://github.com/user-attachments/assets/fc595e0c-f4bb-47f7-ab3f-41c1ee4411c4" />

hover over scroll multiplier tags to see easing

---

<img width="412" height="581" alt="{39E97D41-DDB2-4E0D-9682-BB2C502766C2}" src="https://github.com/user-attachments/assets/8523855b-e4da-40a3-9064-aaad5ab9756a" />

now see easing type for scroll multipliers

---

## Changes
- new scroll multiplier tags in editor act same as sv tags
- better stacking of tags based on zoom and time
- in addition to scroll multiplier tags, hovering over them will show their easing
- now easing type is shown in the scroll multiplier event entry