### PR TITLE
Force UTF8 encoding for strings in Lua

### DIFF
--- a/fluXis/Scripting/ScriptRunner.cs
+++ b/fluXis/Scripting/ScriptRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using fluXis.Map;
 using fluXis.Scripting.Attributes;
 using fluXis.Scripting.Models;
@@ -23,6 +24,7 @@ public class ScriptRunner
     protected ScriptRunner()
     {
         Lua = new Lua();
+        Lua.State.Encoding = Encoding.UTF8;
 
         AddField("mathf", new LuaMath());
 


### PR DESCRIPTION
Fix for
- #157

## Before:
<img width="1870" height="627" alt="{C0785002-1BBF-4D38-882D-B48FB4B95CD0}" src="https://github.com/user-attachments/assets/3be140a4-4ca5-4b0f-a75c-f237bb24d2bb" />

## After:
<img width="1543" height="589" alt="{418E6E00-4769-47CE-827B-5E80537CD19C}" src="https://github.com/user-attachments/assets/c5d55ca1-7f85-4311-985b-98c6302e666f" />

Fixes #157