### PR TITLE
New Color Fade Event + Skin Color Rework

### DIFF
--- a/fluXis/Graphics/UserInterface/Color/Theme.cs
+++ b/fluXis/Graphics/UserInterface/Color/Theme.cs
@@ -60,6 +60,7 @@ public static class Theme
     public static Colour4 PlayfieldMove => Colour4.FromHex("#01FE55");
     public static Colour4 PlayfieldScale => Colour4.FromHex("#D279C4");
     public static Colour4 PlayfieldRotate => Colour4.FromHex("#8AF7A2");
+    public static Colour4 ColorFade => Colour4.FromHex("#90FFFF");
     public static Colour4 HitObjectEase => Colour4.FromHex("#5B92FF");
     public static Colour4 LayerFade => Colour4.FromHex("#8AF3F7");
     public static Colour4 BeatPulse => Colour4.FromHex("#9973EF");

--- a/fluXis/Graphics/UserInterface/Color/Theme.cs
+++ b/fluXis/Graphics/UserInterface/Color/Theme.cs
@@ -226,3 +226,12 @@ public static class Theme
         _ => Colour4.FromHex("#cccccc")
     };
 }
+
+public enum MapColor
+{
+    Accent,
+    Primary,
+    Secondary,
+    Middle,
+    Other,
+}

--- a/fluXis/Graphics/UserInterface/Color/Theme.cs
+++ b/fluXis/Graphics/UserInterface/Color/Theme.cs
@@ -233,7 +233,5 @@ public enum MapColor
     Accent,
     Primary,
     Secondary,
-    Middle,
-    Other,
-    Gradient,
+    Middle
 }

--- a/fluXis/Graphics/UserInterface/Color/Theme.cs
+++ b/fluXis/Graphics/UserInterface/Color/Theme.cs
@@ -234,4 +234,5 @@ public enum MapColor
     Secondary,
     Middle,
     Other,
+    Gradient,
 }

--- a/fluXis/Map/MapColors.cs
+++ b/fluXis/Map/MapColors.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using fluXis.Graphics.UserInterface.Color;
-using fluXis.Skinning.Bases;
 using fluXis.Skinning.Default;
 using Newtonsoft.Json;
 using osu.Framework.Graphics;
@@ -21,11 +19,6 @@ public class MapColors : ICustomColorProvider
 
     [JsonProperty("middle")]
     public string MiddleHex { get; set; } = "";
-
-    public List<ColorableSkinDrawable> CachedDrawables = new();
-
-    public void Register(ColorableSkinDrawable skinDrawable) => CachedDrawables.Add(skinDrawable);
-    public void Unregister(ColorableSkinDrawable skinDrawable) => CachedDrawables.Remove(skinDrawable);
 
     public override string ToString()
         => $"Accent: {AccentHex}, Primary: {PrimaryHex}, Secondary: {SecondaryHex}, Middle: {MiddleHex}";

--- a/fluXis/Map/MapColors.cs
+++ b/fluXis/Map/MapColors.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Bases;
 using fluXis.Skinning.Default;
 using Newtonsoft.Json;
 using osu.Framework.Graphics;
@@ -19,6 +21,11 @@ public class MapColors : ICustomColorProvider
 
     [JsonProperty("middle")]
     public string MiddleHex { get; set; } = "";
+
+    public List<ColorableSkinDrawable> CachedDrawables = new();
+
+    public void Register(ColorableSkinDrawable skinDrawable) => CachedDrawables.Add(skinDrawable);
+    public void Unregister(ColorableSkinDrawable skinDrawable) => CachedDrawables.Remove(skinDrawable);
 
     public override string ToString()
         => $"Accent: {AccentHex}, Primary: {PrimaryHex}, Secondary: {SecondaryHex}, Middle: {MiddleHex}";

--- a/fluXis/Map/MapEvents.cs
+++ b/fluXis/Map/MapEvents.cs
@@ -23,6 +23,9 @@ public class MapEvents
     [JsonProperty("flash")]
     public List<FlashEvent> FlashEvents { get; private set; } = new();
 
+    [JsonProperty("colorfade")]
+    public List<ColorFadeEvent> ColorFadeEvents { get; private set; } = new();
+
     [JsonProperty("pulse")]
     public List<PulseEvent> PulseEvents { get; private set; } = new();
 
@@ -82,6 +85,7 @@ public class MapEvents
     [JsonIgnore]
     public bool Empty => LaneSwitchEvents.Count == 0
                          && FlashEvents.Count == 0
+                         && ColorFadeEvents.Count == 0
                          && PulseEvents.Count == 0
                          && PlayfieldMoveEvents.Count == 0
                          && PlayfieldScaleEvents.Count == 0

--- a/fluXis/Map/Structures/Events/ColorFadeEvent.cs
+++ b/fluXis/Map/Structures/Events/ColorFadeEvent.cs
@@ -1,6 +1,7 @@
 using System;
 using fluXis.Map.Structures.Bases;
 using fluXis.Screens.Gameplay.Ruleset.Playfields;
+using Midori.Logging;
 using Newtonsoft.Json;
 using osu.Framework.Graphics;
 using osuTK.Graphics;
@@ -12,11 +13,20 @@ public class ColorFadeEvent : IMapEvent, IHasDuration, IHasEasing, IApplicableTo
     [JsonProperty("time")]
     public double Time { get; set; }
 
+    [JsonProperty("fade-primary")]
+    public bool FadePrimary { get; set; } = false;
+
     [JsonProperty("primary")]
     public Color4 Primary { get; set; } = Color4.White;
 
+    [JsonProperty("fade-secondary")]
+    public bool FadeSecondary { get; set; } = false;
+
     [JsonProperty("secondary")]
     public Color4 Secondary { get; set; } = Color4.White;
+
+    [JsonProperty("fade-middle")]
+    public bool FadeMiddle { get; set; } = false;
 
     [JsonProperty("middle")]
     public Color4 Middle { get; set; } = Color4.White;
@@ -41,9 +51,12 @@ public class ColorFadeEvent : IMapEvent, IHasDuration, IHasEasing, IApplicableTo
         using (playfield.BeginAbsoluteSequence(Time))
         {
             var manager = playfield.ColorManager;
-            manager.TransformTo(nameof(ColorManager.Primary), (Colour4)Primary, Math.Max(Duration, 0), Easing);
-            manager.TransformTo(nameof(ColorManager.Secondary), (Colour4)Secondary, Math.Max(Duration, 0), Easing);
-            manager.TransformTo(nameof(ColorManager.Middle), (Colour4)Middle, Math.Max(Duration, 0), Easing);
+            if (FadePrimary)
+                manager.TransformTo(nameof(ColorManager.Primary), (Colour4)Primary, Math.Max(Duration, 0), Easing);
+            if (FadeSecondary)
+                manager.TransformTo(nameof(ColorManager.Secondary), (Colour4)Secondary, Math.Max(Duration, 0), Easing);
+            if (FadeMiddle)
+                manager.TransformTo(nameof(ColorManager.Middle), (Colour4)Middle, Math.Max(Duration, 0), Easing);
         }
     }
 }

--- a/fluXis/Map/Structures/Events/ColorFadeEvent.cs
+++ b/fluXis/Map/Structures/Events/ColorFadeEvent.cs
@@ -1,5 +1,4 @@
 using System;
-using fluXis.Graphics.UserInterface.Color;
 using fluXis.Map.Structures.Bases;
 using fluXis.Screens.Gameplay.Ruleset.Playfields;
 using Newtonsoft.Json;
@@ -41,9 +40,10 @@ public class ColorFadeEvent : IMapEvent, IHasDuration, IHasEasing, IApplicableTo
 
         using (playfield.BeginAbsoluteSequence(Time))
         {
-            playfield.ColorManager.FadeColor(MapColor.Primary, (Colour4)Primary, Time, Math.Max(Duration, 0), Easing);
-            playfield.ColorManager.FadeColor(MapColor.Secondary, (Colour4)Secondary, Time, Math.Max(Duration, 0), Easing);
-            playfield.ColorManager.FadeColor(MapColor.Middle, (Colour4)Middle, Time, Math.Max(Duration, 0), Easing);
+            var manager = playfield.ColorManager;
+            manager.TransformTo(nameof(ColorManager.Primary), (Colour4)Primary, Math.Max(Duration, 0), Easing);
+            manager.TransformTo(nameof(ColorManager.Secondary), (Colour4)Secondary, Math.Max(Duration, 0), Easing);
+            manager.TransformTo(nameof(ColorManager.Middle), (Colour4)Middle, Math.Max(Duration, 0), Easing);
         }
     }
 }

--- a/fluXis/Map/Structures/Events/ColorFadeEvent.cs
+++ b/fluXis/Map/Structures/Events/ColorFadeEvent.cs
@@ -1,0 +1,49 @@
+using System;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Map.Structures.Bases;
+using fluXis.Screens.Gameplay.Ruleset.Playfields;
+using Newtonsoft.Json;
+using osu.Framework.Graphics;
+using osuTK.Graphics;
+
+namespace fluXis.Map.Structures.Events;
+
+public class ColorFadeEvent : IMapEvent, IHasDuration, IHasEasing, IApplicableToPlayfield
+{
+    [JsonProperty("time")]
+    public double Time { get; set; }
+
+    [JsonProperty("primary")]
+    public Color4 Primary { get; set; } = Color4.White;
+
+    [JsonProperty("secondary")]
+    public Color4 Secondary { get; set; } = Color4.White;
+
+    [JsonProperty("middle")]
+    public Color4 Middle { get; set; } = Color4.White;
+
+    [JsonProperty("duration")]
+    public double Duration { get; set; } = 0;
+
+    [JsonProperty("ease")]
+    public Easing Easing { get; set; } = Easing.None;
+
+    [JsonProperty("playfield")]
+    public int PlayfieldIndex { get; set; }
+
+    [JsonProperty("subfield")]
+    public int PlayfieldSubIndex { get; set; }
+
+    public void Apply(Playfield playfield)
+    {
+        if (!this.AppliesTo(playfield))
+            return;
+
+        using (playfield.BeginAbsoluteSequence(Time))
+        {
+            playfield.ColorManager.FadeColor(MapColor.Primary, (Colour4)Primary, Time, Math.Max(Duration, 0), Easing);
+            playfield.ColorManager.FadeColor(MapColor.Secondary, (Colour4)Secondary, Time, Math.Max(Duration, 0), Easing);
+            playfield.ColorManager.FadeColor(MapColor.Middle, (Colour4)Middle, Time, Math.Max(Duration, 0), Easing);
+        }
+    }
+}

--- a/fluXis/Mods/NoEventMod.cs
+++ b/fluXis/Mods/NoEventMod.cs
@@ -19,6 +19,7 @@ public class NoEventMod : IMod, IApplicableToEvents
     public void Apply(MapEvents events)
     {
         events.FlashEvents.Clear();
+        events.ColorFadeEvents.Clear();
         events.PulseEvents.Clear();
         events.PlayfieldMoveEvents.Clear();
         events.PlayfieldScaleEvents.Clear();

--- a/fluXis/Online/API/Models/Maps/MapEffectType.cs
+++ b/fluXis/Online/API/Models/Maps/MapEffectType.cs
@@ -22,6 +22,8 @@ public enum MapEffectType : ulong
     LayerFade = 1 << 11,
     HitObjectEase = 1 << 12,
     ScrollMultiply = 1 << 13,
-    TimeOffset = 1 << 14
+    TimeOffset = 1 << 14,
+
+    ColorFade = 1 << 15
 }
 

--- a/fluXis/Screens/Edit/EditorMap.cs
+++ b/fluXis/Screens/Edit/EditorMap.cs
@@ -80,6 +80,10 @@ public class EditorMap : IVerifyContext
     public event Action<FlashEvent> FlashEventRemoved;
     public event Action<FlashEvent> FlashEventUpdated;
 
+    public event Action<ColorFadeEvent> ColorFadeEventAdded;
+    public event Action<ColorFadeEvent> ColorFadeEventRemoved;
+    public event Action<ColorFadeEvent> ColorFadeEventUpdated;
+
     public event Action<PulseEvent> PulseEventAdded;
     public event Action<PulseEvent> PulseEventRemoved;
     public event Action<PulseEvent> PulseEventUpdated;
@@ -146,6 +150,7 @@ public class EditorMap : IVerifyContext
             new ChangeNotifier<LaneSwitchEvent>(MapEvents.LaneSwitchEvents, obj => LaneSwitchEventAdded?.Invoke(obj), obj => LaneSwitchEventRemoved?.Invoke(obj),
                 obj => LaneSwitchEventUpdated?.Invoke(obj)),
             new ChangeNotifier<FlashEvent>(MapEvents.FlashEvents, obj => FlashEventAdded?.Invoke(obj), obj => FlashEventRemoved?.Invoke(obj), obj => FlashEventUpdated?.Invoke(obj)),
+            new ChangeNotifier<ColorFadeEvent>(MapEvents.ColorFadeEvents, obj => ColorFadeEventAdded?.Invoke(obj), obj => ColorFadeEventRemoved?.Invoke(obj), obj => ColorFadeEventUpdated?.Invoke(obj)),
             new ChangeNotifier<PulseEvent>(MapEvents.PulseEvents, obj => PulseEventAdded?.Invoke(obj), obj => PulseEventRemoved?.Invoke(obj), obj => PulseEventUpdated?.Invoke(obj)),
             new ChangeNotifier<PlayfieldMoveEvent>(MapEvents.PlayfieldMoveEvents, obj => PlayfieldMoveEventAdded?.Invoke(obj), obj => PlayfieldMoveEventRemoved?.Invoke(obj),
                 obj => PlayfieldMoveEventUpdated?.Invoke(obj)),

--- a/fluXis/Screens/Edit/EditorMap.cs
+++ b/fluXis/Screens/Edit/EditorMap.cs
@@ -140,6 +140,8 @@ public class EditorMap : IVerifyContext
 
     public void LoadComponent(Drawable drawable) => loadComponent.Invoke(drawable);
 
+    public void TriggerAnyChange(ITimedObject obj = null) => AnyChange?.Invoke(obj);
+
     public void SetupNotifiers()
     {
         notifiers = new List<IChangeNotifier>

--- a/fluXis/Screens/Edit/Tabs/Charting/Playfield/Objects/EditorLongNote.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Playfield/Objects/EditorLongNote.cs
@@ -34,13 +34,13 @@ public partial class EditorLongNote : EditorHitObject
 
     protected override IEnumerable<Drawable> CreateContent() => new[]
     {
-        head = new DefaultHitObjectPiece(null),
-        body = new DefaultHitObjectBody(null).With(b =>
+        head = new DefaultHitObjectPiece(null, 0),
+        body = new DefaultHitObjectBody(null, 0).With(b =>
         {
             b.Anchor = Anchor.BottomCentre;
             b.Origin = Anchor.BottomCentre;
         }),
-        End = new DefaultHitObjectEnd(null).With(e =>
+        End = new DefaultHitObjectEnd(null, 0).With(e =>
         {
             e.Anchor = Anchor.BottomCentre;
             e.Origin = Anchor.BottomCentre;

--- a/fluXis/Screens/Edit/Tabs/Charting/Playfield/Objects/EditorSingleNote.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Playfield/Objects/EditorSingleNote.cs
@@ -17,7 +17,7 @@ public partial class EditorSingleNote : EditorHitObject
 
     protected override IEnumerable<Drawable> CreateContent()
     {
-        yield return piece = new DefaultHitObjectPiece(null);
+        yield return piece = new DefaultHitObjectPiece(null, 0);
     }
 
     protected override void LoadComplete()

--- a/fluXis/Screens/Edit/Tabs/Design/Points/DesignPointsList.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/DesignPointsList.cs
@@ -22,6 +22,11 @@ public partial class DesignPointsList : PointsList
         Map.FlashEventRemoved += RemovePoint;
         Map.MapEvents.FlashEvents.ForEach(AddPoint);
 
+        Map.ColorFadeEventAdded += AddPoint;
+        Map.ColorFadeEventUpdated += UpdatePoint;
+        Map.ColorFadeEventRemoved += RemovePoint;
+        Map.MapEvents.ColorFadeEvents.ForEach(AddPoint);
+
         Map.PulseEventAdded += AddPoint;
         Map.PulseEventUpdated += UpdatePoint;
         Map.PulseEventRemoved += RemovePoint;
@@ -92,6 +97,7 @@ public partial class DesignPointsList : PointsList
     {
         ScrollVelocity scroll => new ScrollVelocityEntry(scroll),
         FlashEvent flash => new FlashEntry(flash),
+        ColorFadeEvent colorFade => new ColorFadeEntry(colorFade),
         PulseEvent pulse => new PulseEntry(pulse),
         ShakeEvent shake => new ShakeEntry(shake),
         PlayfieldMoveEvent move => new PlayfieldMoveEntry(move),
@@ -114,6 +120,7 @@ public partial class DesignPointsList : PointsList
         {
             new("Scroll Velocity", Theme.ScrollVelocity, () => Create(new ScrollVelocity()), x => x is ScrollVelocity),
             new("Flash", Theme.Flash, () => Create(new FlashEvent()), x => x is FlashEvent),
+            new("Color Fade", Theme.ColorFade, () => Create(new ColorFadeEvent()), x => x is ColorFadeEvent),
             new("Pulse", Theme.Pulse, () => Create(new PulseEvent()), x => x is PulseEvent),
             new("Shake", Theme.Shake, () => Create(new ShakeEvent()), x => x is ShakeEvent),
             new("Playfield Move", Theme.PlayfieldMove, () => Create(new PlayfieldMoveEvent()), x => x is PlayfieldMoveEvent),

--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ColorFadeEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ColorFadeEntry.cs
@@ -56,7 +56,7 @@ public partial class ColorFadeEntry : PointListEntry
             },
             new FluXisSpriteText
             {
-                Text = $"{(int)colorFade.Duration}ms",
+                Text = $"{(int)colorFade.Duration}ms P{colorFade.PlayfieldIndex}S{colorFade.PlayfieldSubIndex}",
                 Colour = Color
             }
         };

--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ColorFadeEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ColorFadeEntry.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Linq;
+using fluXis.Graphics.Sprites.Text;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Map.Structures.Bases;
+using fluXis.Map.Structures.Events;
+using fluXis.Screens.Edit.Tabs.Shared.Points.List;
+using fluXis.Screens.Edit.Tabs.Shared.Points.Settings;
+using fluXis.Screens.Edit.Tabs.Shared.Points.Settings.Preset;
+using fluXis.Utils;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace fluXis.Screens.Edit.Tabs.Design.Points.Entries;
+
+public partial class ColorFadeEntry : PointListEntry
+{
+    protected override string Text => "Color Fade";
+    protected override Colour4 Color => Theme.ColorFade;
+
+    private ColorFadeEvent colorFade => Object as ColorFadeEvent;
+
+    public ColorFadeEntry(ColorFadeEvent obj)
+        : base(obj)
+    {
+    }
+
+    public override ITimedObject CreateClone() => colorFade.JsonCopy();
+
+    protected override Drawable[] CreateValueContent()
+    {
+        return new Drawable[]
+        {
+            new Circle
+            {
+                Size = new Vector2(20),
+                Colour = colorFade.Primary,
+                Margin = new MarginPadding { Right = 10 }
+            },
+            new Circle
+            {
+                Size = new Vector2(20),
+                Colour = colorFade.Secondary,
+                Margin = new MarginPadding { Right = 4 }
+            },
+            new Circle
+            {
+                Size = new Vector2(20),
+                Colour = colorFade.Middle,
+                Margin = new MarginPadding { Right = 10 }
+            },
+            new FluXisSpriteText
+            {
+                Text = $"{(int)colorFade.Duration}ms",
+                Colour = Color
+            }
+        };
+    }
+
+    protected override IEnumerable<Drawable> CreateSettings()
+    {
+        return base.CreateSettings().Concat(new Drawable[]
+        {
+            new PointSettingsLength<ColorFadeEvent>(Map, colorFade, BeatLength),
+            new PointSettingsColor
+            {
+                Text = "Primary",
+                TooltipText = "Color of the primary lane, right playfield border & Health top gradient.",
+                Color = colorFade.Primary,
+                OnColorChanged = c =>
+                {
+                    colorFade.Primary = c;
+                    Map.Update(colorFade);
+                }
+            },
+            new PointSettingsColor
+            {
+                Text = "Secondary",
+                TooltipText = "Color of the secondary lane, left playfield border & Health Bottom gradient.",
+                Color = colorFade.Secondary,
+                OnColorChanged = c =>
+                {
+                    colorFade.Secondary = c;
+                    Map.Update(colorFade);
+                }
+            },
+            new PointSettingsColor
+            {
+                Text = "Middle",
+                TooltipText = "Color of the middle lane.",
+                Color = colorFade.Middle,
+                OnColorChanged = c =>
+                {
+                    colorFade.Middle = c;
+                    Map.Update(colorFade);
+                }
+            },
+            new PointSettingsEasing<ColorFadeEvent>(Map, colorFade),
+            new PointSettingsSlider<int>
+            {
+                Text = "Player Index",
+                TooltipText = "The player to apply this to.",
+                CurrentValue = colorFade.PlayfieldIndex,
+                Min = 0,
+                Max = Map.MapInfo.IsDual ? 2 : 0,
+                Step = 1,
+                OnValueChanged = value =>
+                {
+                    colorFade.PlayfieldIndex = value;
+                    Map.Update(colorFade);
+                }
+            },
+            new PointSettingsSlider<int>
+            {
+                Text = "Subfield Index",
+                TooltipText = "The subfield to apply this to.",
+                CurrentValue = colorFade.PlayfieldSubIndex,
+                Min = 0,
+                Max = Map.MapInfo.ExtraPlayfields + 1,
+                Step = 1,
+                OnValueChanged = value =>
+                {
+                    colorFade.PlayfieldSubIndex = value;
+                    Map.Update(colorFade);
+                }
+            }
+        });
+    }
+}

--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ColorFadeEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/ColorFadeEntry.cs
@@ -8,6 +8,7 @@ using fluXis.Screens.Edit.Tabs.Shared.Points.List;
 using fluXis.Screens.Edit.Tabs.Shared.Points.Settings;
 using fluXis.Screens.Edit.Tabs.Shared.Points.Settings.Preset;
 using fluXis.Utils;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
@@ -36,18 +37,21 @@ public partial class ColorFadeEntry : PointListEntry
             {
                 Size = new Vector2(20),
                 Colour = colorFade.Primary,
-                Margin = new MarginPadding { Right = 10 }
+                Alpha = colorFade.FadePrimary ? 1f : .4f,
+                Margin = new MarginPadding { Right = 4 }
             },
             new Circle
-            {
+            {   
                 Size = new Vector2(20),
                 Colour = colorFade.Secondary,
+                Alpha = colorFade.FadeSecondary ? 1f : .4f,
                 Margin = new MarginPadding { Right = 4 }
             },
             new Circle
             {
                 Size = new Vector2(20),
                 Colour = colorFade.Middle,
+                Alpha = colorFade.FadeMiddle ? 1f : .4f,
                 Margin = new MarginPadding { Right = 10 }
             },
             new FluXisSpriteText
@@ -60,13 +64,51 @@ public partial class ColorFadeEntry : PointListEntry
 
     protected override IEnumerable<Drawable> CreateSettings()
     {
+        var primaryToggle = new PointSettingsToggle
+        {
+            Text = "Fade Primary",
+            TooltipText = "Enables whether Primary color should be faded.",
+            Bindable = new Bindable<bool>(colorFade.FadePrimary),
+            OnStateChanged = enabled =>
+            {
+                colorFade.FadePrimary = enabled;
+                Map.Update(colorFade);
+            }
+        };
+
+        var secondaryToggle = new PointSettingsToggle
+        {
+            Text = "Fade secondary",
+            TooltipText = "Enables whether secondary color should be faded.",
+            Bindable = new Bindable<bool>(colorFade.FadeSecondary),
+            OnStateChanged = enabled =>
+            {
+                colorFade.FadeSecondary = enabled;
+                Map.Update(colorFade);
+            }
+        };
+
+        var middleToggle = new PointSettingsToggle
+        {
+            Text = "Fade middle",
+            TooltipText = "Enables whether middle color should be faded.",
+            Bindable = new Bindable<bool>(colorFade.FadeMiddle),
+            OnStateChanged = enabled =>
+            {
+                colorFade.FadeMiddle = enabled;
+                Map.Update(colorFade);
+            }
+        };
+
         return base.CreateSettings().Concat(new Drawable[]
         {
             new PointSettingsLength<ColorFadeEvent>(Map, colorFade, BeatLength),
+            primaryToggle,
             new PointSettingsColor
             {
+                Enabled = primaryToggle.Bindable,
                 Text = "Primary",
-                TooltipText = "Color of the primary lane, right playfield border & Health top gradient.",
+                TooltipText = "Color of the primary lane, left stage border & Health top gradient.",
                 Color = colorFade.Primary,
                 OnColorChanged = c =>
                 {
@@ -74,10 +116,12 @@ public partial class ColorFadeEntry : PointListEntry
                     Map.Update(colorFade);
                 }
             },
+            secondaryToggle,
             new PointSettingsColor
             {
+                Enabled = secondaryToggle.Bindable,
                 Text = "Secondary",
-                TooltipText = "Color of the secondary lane, left playfield border & Health Bottom gradient.",
+                TooltipText = "Color of the secondary lane, right stage border & Health Bottom gradient.",
                 Color = colorFade.Secondary,
                 OnColorChanged = c =>
                 {
@@ -85,8 +129,10 @@ public partial class ColorFadeEntry : PointListEntry
                     Map.Update(colorFade);
                 }
             },
+            middleToggle,
             new PointSettingsColor
             {
+                Enabled = middleToggle.Bindable,
                 Text = "Middle",
                 TooltipText = "Color of the middle lane.",
                 Color = colorFade.Middle,

--- a/fluXis/Screens/Edit/Tabs/SetupTab.cs
+++ b/fluXis/Screens/Edit/Tabs/SetupTab.cs
@@ -136,17 +136,29 @@ public partial class SetupTab : EditorTab
                                                         new SetupColor("Primary")
                                                         {
                                                             Color = map.MapInfo.Colors.GetColor(1, Colour4.White),
-                                                            OnColorChanged = color => map.MapInfo.Colors.PrimaryHex = color.ToHex()
+                                                            OnColorChanged = color =>
+                                                            {
+                                                                map.MapInfo.Colors.PrimaryHex = color.ToHex();
+                                                                map.TriggerAnyChange();
+                                                            }
                                                         },
                                                         new SetupColor("Secondary")
                                                         {
                                                             Color = map.MapInfo.Colors.GetColor(2, Colour4.White),
-                                                            OnColorChanged = color => map.MapInfo.Colors.SecondaryHex = color.ToHex()
+                                                            OnColorChanged = color =>
+                                                            {
+                                                                map.MapInfo.Colors.SecondaryHex = color.ToHex();
+                                                                map.TriggerAnyChange();
+                                                            }
                                                         },
                                                         new SetupColor("Middle")
                                                         {
                                                             Color = map.MapInfo.Colors.GetColor(3, Colour4.White),
-                                                            OnColorChanged = color => map.MapInfo.Colors.MiddleHex = color.ToHex()
+                                                            OnColorChanged = color =>
+                                                            {
+                                                                map.MapInfo.Colors.MiddleHex = color.ToHex();
+                                                                map.TriggerAnyChange();
+                                                            }
                                                         }
                                                     }
                                                 },

--- a/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/PointSettingsColor.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/PointSettingsColor.cs
@@ -22,6 +22,10 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
     public Action<Colour4> OnColorChanged { get; set; } = _ => { };
     public Bindable<Colour4> Bindable { get; set; }
 
+    public Bindable<bool> Enabled { get; init; } = new(true);
+    public bool HideWhenDisabled { get; init; } = false;
+
+    private FullInputBlockingContainer inputBlockingContainer;
     private Circle textBackground;
     private FluXisSpriteText text;
 
@@ -60,9 +64,10 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
                         Origin = Anchor.Centre,
                         FontSize = 16,
                         FixedWidth = true
-                    }
+                    },
+                    inputBlockingContainer = new FullInputBlockingContainer{ RelativeSizeAxes = Axes.Both },
                 }
-            }
+            },
         };
     }
 
@@ -72,6 +77,9 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
 
         updateColors(Color);
         Bindable.BindValueChanged(valueChanged);
+        Enabled.BindValueChanged(e => this.FadeTo(e.NewValue ? 1f : HideWhenDisabled ? 0 : .4f, 200), true);
+        Enabled.BindValueChanged(e => inputBlockingContainer.Alpha = e.NewValue ? 0f : 1f, true);
+        FinishTransforms();
     }
 
     protected override void Dispose(bool isDisposing)

--- a/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/PointSettingsColor.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/PointSettingsColor.cs
@@ -25,7 +25,7 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
     public Bindable<bool> Enabled { get; init; } = new(true);
     public bool HideWhenDisabled { get; init; } = false;
 
-    private FullInputBlockingContainer inputBlockingContainer;
+    private ClickableContainer colorContainer;
     private Circle textBackground;
     private FluXisSpriteText text;
 
@@ -46,7 +46,7 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
                 Origin = Anchor.CentreLeft,
                 WebFontSize = 16
             },
-            new ClickableContainer
+            colorContainer = new ClickableContainer
             {
                 RelativeSizeAxes = Axes.Y,
                 Width = 100,
@@ -65,7 +65,6 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
                         FontSize = 16,
                         FixedWidth = true
                     },
-                    inputBlockingContainer = new FullInputBlockingContainer{ RelativeSizeAxes = Axes.Both },
                 }
             },
         };
@@ -77,8 +76,11 @@ public partial class PointSettingsColor : Container, IHasPopover, IHasTooltip
 
         updateColors(Color);
         Bindable.BindValueChanged(valueChanged);
-        Enabled.BindValueChanged(e => this.FadeTo(e.NewValue ? 1f : HideWhenDisabled ? 0 : .4f, 200), true);
-        Enabled.BindValueChanged(e => inputBlockingContainer.Alpha = e.NewValue ? 0f : 1f, true);
+        Enabled.BindValueChanged(e => 
+        {
+            this.FadeTo(e.NewValue ? 1f : HideWhenDisabled ? 0 : .4f, 200);
+            colorContainer.Action = e.NewValue ? this.ShowPopover : () => {};
+        }, true);
         FinishTransforms();
     }
 

--- a/fluXis/Screens/Gameplay/HUD/GameplayHUD.cs
+++ b/fluXis/Screens/Gameplay/HUD/GameplayHUD.cs
@@ -6,6 +6,7 @@ using fluXis.Screens.Gameplay.HUD.Leaderboard;
 using fluXis.Screens.Gameplay.Ruleset;
 using fluXis.Screens.Gameplay.Ruleset.Playfields;
 using fluXis.Screens.Gameplay.UI;
+using fluXis.Skinning.Default;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -171,6 +172,8 @@ public partial class GameplayHUD : Container
         public PlayfieldPlayer Player { get; }
         public Playfield Playfield => Player.MainPlayfield;
 
+        private DependencyContainer dependencies;
+
         public PlayfieldHUD(PlayfieldPlayer player)
         {
             Player = player;
@@ -179,6 +182,15 @@ public partial class GameplayHUD : Container
             RelativeSizeAxes = Axes.Y;
             Anchor = Origin = Anchor.Centre;
         }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            dependencies.CacheAs<ICustomColorProvider>(Playfield.ColorManager);
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
         protected override void Update()
         {

--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/DrawableHitObject.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/DrawableHitObject.cs
@@ -5,7 +5,6 @@ using fluXis.Map.Structures;
 using fluXis.Scoring;
 using fluXis.Screens.Gameplay.Input;
 using fluXis.Screens.Gameplay.Ruleset.HitObjects.Long;
-using fluXis.Screens.Gameplay.Ruleset.Playfields;
 using fluXis.Skinning;
 using fluXis.Skinning.Bases;
 using osu.Framework.Allocation;
@@ -92,7 +91,7 @@ public partial class DrawableHitObject : CompositeDrawable
                 case ColorableSkinDrawable drawable:
                     yield return drawable;
                     break;
-                    
+
                 default:
                     if (child.Parent is DrawableLongNote drawableLongNote)
                     {
@@ -116,7 +115,7 @@ public partial class DrawableHitObject : CompositeDrawable
                 {
                     if (notePartChild is ColorableSkinDrawable drawable)
                         yield return drawable;
-                } 
+                }
             }
         }
     }

--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/DrawableHitObject.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/DrawableHitObject.cs
@@ -5,6 +5,7 @@ using fluXis.Map.Structures;
 using fluXis.Scoring;
 using fluXis.Screens.Gameplay.Input;
 using fluXis.Screens.Gameplay.Ruleset.HitObjects.Long;
+using fluXis.Screens.Gameplay.Ruleset.Playfields;
 using fluXis.Skinning;
 using fluXis.Skinning.Bases;
 using osu.Framework.Allocation;
@@ -120,7 +121,7 @@ public partial class DrawableHitObject : CompositeDrawable
         }
     }
 
-    public void ChangeColor(Colour4 colour)
+    public void SetColor(Colour4 colour)
     {
         foreach (var drawable in GetColorableDrawables())
         {

--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/DrawableHitObject.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/DrawableHitObject.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 using fluXis.Input;
 using fluXis.Map.Structures;
 using fluXis.Scoring;
 using fluXis.Screens.Gameplay.Input;
+using fluXis.Screens.Gameplay.Ruleset.HitObjects.Long;
 using fluXis.Skinning;
+using fluXis.Skinning.Bases;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -25,7 +28,7 @@ public partial class DrawableHitObject : CompositeDrawable
     protected GameplayInput Input { get; private set; }
 
     [Resolved]
-    protected ISkin Skin { get; private set; }
+    public ISkin Skin { get; private set; }
 
     public HitObject Data { get; }
     protected double ScrollVelocityTime { get; private set; }
@@ -64,6 +67,7 @@ public partial class DrawableHitObject : CompositeDrawable
     {
         AutoSizeAxes = Axes.Y;
         Origin = Anchor.BottomLeft;
+        Masking = true;
 
         var group = Data.ScrollGroup ?? Column.DefaultScrollGroup;
         ScrollVelocityTime = group.PositionFromTime(Data.Time);
@@ -76,6 +80,52 @@ public partial class DrawableHitObject : CompositeDrawable
 
         Input.OnPress += OnPressed;
         Input.OnRelease += OnReleased;
+    }
+
+    public IEnumerable<ColorableSkinDrawable> GetColorableDrawables()
+    {
+        foreach (var child in InternalChildren)
+        {
+            switch (child)
+            {
+                case ColorableSkinDrawable drawable:
+                    yield return drawable;
+                    break;
+                    
+                default:
+                    if (child.Parent is DrawableLongNote drawableLongNote)
+                    {
+                        foreach (var longNoteDrawable in getLongNoteColorableDrawables(drawableLongNote))
+                        {
+                            yield return longNoteDrawable;
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+    private IEnumerable<ColorableSkinDrawable> getLongNoteColorableDrawables(DrawableLongNote longNote)
+    {
+        foreach (var lnChild in longNote.InternalChildren)
+        {
+            if (lnChild is DrawableLongNotePart notePart)
+            {
+                foreach (var notePartChild in notePart.GetInternalChildren())
+                {
+                    if (notePartChild is ColorableSkinDrawable drawable)
+                        yield return drawable;
+                } 
+            }
+        }
+    }
+
+    public void ChangeColor(Colour4 colour)
+    {
+        foreach (var drawable in GetColorableDrawables())
+        {
+            drawable.SetColor(colour);
+        }
     }
 
     protected override void Update()

--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/HitObjectColumn.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/HitObjectColumn.cs
@@ -20,7 +20,7 @@ public partial class HitObjectColumn : Container<DrawableHitObject>
     private const float minimum_loaded_hit_objects = 3;
 
     [Resolved]
-    private Playfield playfield { get; set; }
+    public Playfield Playfield { get; private set; }
 
     [Resolved]
     private PlayfieldPlayer player { get; set; }
@@ -199,7 +199,7 @@ public partial class HitObjectColumn : Container<DrawableHitObject>
 
     private void revertHitObject(HitObject hit)
     {
-        if (!playfield.IsSubPlayfield)
+        if (!Playfield.IsSubPlayfield)
         {
             if (hit.HoldEndResult is not null)
                 judgementProcessor.RevertResult(hit.HoldEndResult.Value);
@@ -241,7 +241,7 @@ public partial class HitObjectColumn : Container<DrawableHitObject>
 
     private void hit(DrawableHitObject hitObject, double difference)
     {
-        if (playfield.IsSubPlayfield)
+        if (Playfield.IsSubPlayfield)
             return;
 
         // since judged is only set after hitting the tail this works

--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/Long/DrawableLongNotePart.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/Long/DrawableLongNotePart.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using fluXis.Map.Structures;
 using fluXis.Scoring;
 using fluXis.Skinning;

--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/Long/DrawableLongNotePart.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/Long/DrawableLongNotePart.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using fluXis.Map.Structures;
 using fluXis.Scoring;
 using fluXis.Skinning;
@@ -63,6 +65,8 @@ public partial class DrawableLongNotePart : CompositeDrawable
         var child = InternalChild as ICanHaveSnapColor;
         child?.ApplySnapColor(idx, 0);
     }
+
+    public IReadOnlyList<Drawable> GetInternalChildren() => InternalChildren;
 
     protected override void Update()
     {

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
@@ -41,30 +41,34 @@ public partial class ColorManager : Component, ICustomColorProvider
     public void Register(ColorableSkinDrawable skinDrawable) => colorableDrawables.Add(skinDrawable);
     public void Unregister(ColorableSkinDrawable skinDrawable) => colorableDrawables.Remove(skinDrawable);
 
+
+    private void UpdateColor(MapColor index, Colour4 color)
+    {
+        switch (index)
+        {
+            case MapColor.Primary:
+                Primary = color;
+                break;
+
+            case MapColor.Secondary:
+                Secondary = color;
+                break;
+
+            case MapColor.Middle:
+                Middle = color;
+                break;
+        }
+    }
+
     public void SetColor(MapColor index, Colour4 color)
     {
-        // Not implemented yet
         colorableDrawables.ForEach(drawable =>
         {
-            // Logger.Log($"{drawable.Index}");
             if (drawable.Index == index)
             {
                 drawable.SetColor(color);
 
-                switch (drawable.Index)
-                {
-                    case MapColor.Primary:
-                        Primary = color;
-                        break;
-
-                    case MapColor.Secondary:
-                        Secondary = color;
-                        break;
-
-                    case MapColor.Middle:
-                        Middle = color;
-                        break;
-                }
+                UpdateColor(drawable.Index, color);
             }
         });
         ColorChanged?.Invoke(color);
@@ -72,7 +76,15 @@ public partial class ColorManager : Component, ICustomColorProvider
 
     public void FadeColor(MapColor index, Colour4 color, double duration = 0, Easing easing = Easing.None)
     {
-        // Not implemented yet
+        colorableDrawables.ForEach(drawable =>
+        {
+            if (drawable.Index == index)
+            {
+                drawable.FadeColor(color, duration, easing);
+
+                UpdateColor(drawable.Index, color);
+            }
+        });
         ColorChanged?.Invoke(color);
     }
 

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
@@ -56,10 +56,12 @@ public partial class ColorManager : Component, ICustomColorProvider
     [BackgroundDependencyLoader(true)]
     private void load([CanBeNull] ICustomColorProvider mapColors)
     {
-        Primary = mapColors?.Primary ?? Primary;
-        Secondary = mapColors?.Secondary ?? Secondary;
-        Middle = mapColors?.Middle ?? Middle;
+        Primary = isDefaultColor(mapColors.Primary) ? Primary : mapColors.Primary;
+        Secondary = isDefaultColor(mapColors.Secondary) ? Secondary : mapColors.Secondary;
+        Middle = isDefaultColor(mapColors.Middle) ? Middle : mapColors.Middle;
     }
+
+    private static bool isDefaultColor(Colour4 colour) => colour == Colour4.Transparent;
 
     public void Register(ColorableSkinDrawable draw, MapColor index) => drawables.Add((draw, index));
     public void Unregister(ColorableSkinDrawable draw, MapColor index) => drawables.RemoveAll(x => x.draw == draw && x.idx == index);

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using fluXis.Map;
+using fluXis.Skinning.Bases;
+using fluXis.Skinning.Default;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+
+namespace fluXis.Screens.Gameplay.Ruleset.Playfields;
+
+public partial class ColorManager : Component, ICustomColorProvider
+{
+    [Resolved]
+    private MapColors mapColors { get; set; } = new();
+
+    private Playfield playfield;
+    private List<ColorableSkinDrawable> colorableDrawables;
+
+    public Colour4 Primary => mapColors.Primary;
+
+    public Colour4 Secondary => mapColors.Secondary;
+
+    public Colour4 Middle => mapColors.Middle;
+
+    public event Action<Colour4> ColorChanged;
+
+    public ColorManager(Playfield playfield)
+    {
+        this.playfield = playfield;
+        colorableDrawables = new();
+    }
+
+    public void Register(ColorableSkinDrawable skinDrawable) => colorableDrawables.Add(skinDrawable);
+    public void Unregister(ColorableSkinDrawable skinDrawable) => colorableDrawables.Remove(skinDrawable);
+
+    public void SetColor(int lane, Colour4 color)
+    {
+        // Not implemented yet
+        ColorChanged?.Invoke(color);
+    }
+
+    public void FadeColor(int lane, Colour4 color, double duration = 0, Easing easing = Easing.None)
+    {
+        // Not implemented yet
+        ColorChanged?.Invoke(color);
+    }
+
+    public bool HasColorFor(int lane, int keyCount, out Colour4 colour) => mapColors.HasColorFor(lane, keyCount, out colour);
+
+    public Colour4 GetColor(int index, Colour4 fallback) => mapColors.GetColor(index, fallback);
+}

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/ColorManager.cs
@@ -1,26 +1,26 @@
 using System;
 using System.Collections.Generic;
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Map;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Default;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 
 namespace fluXis.Screens.Gameplay.Ruleset.Playfields;
 
 public partial class ColorManager : Component, ICustomColorProvider
 {
-    [Resolved]
-    private MapColors mapColors { get; set; } = new();
+    [Resolved(CanBeNull = true)]
+    private ICustomColorProvider mapColors { get; set; }
 
     private Playfield playfield;
     private List<ColorableSkinDrawable> colorableDrawables;
 
-    public Colour4 Primary => mapColors.Primary;
-
-    public Colour4 Secondary => mapColors.Secondary;
-
-    public Colour4 Middle => mapColors.Middle;
+    public Colour4 Primary { get; private set; } = Theme.Primary;
+    public Colour4 Secondary { get; private set; } = Theme.Secondary;
+    public Colour4 Middle { get; private set; } = Colour4.White;
 
     public event Action<Colour4> ColorChanged;
 
@@ -30,22 +30,77 @@ public partial class ColorManager : Component, ICustomColorProvider
         colorableDrawables = new();
     }
 
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Primary = mapColors?.Primary ?? Primary;
+        Secondary = mapColors?.Primary ?? Secondary;
+        Middle = mapColors?.Middle ?? Middle;
+    }
+
     public void Register(ColorableSkinDrawable skinDrawable) => colorableDrawables.Add(skinDrawable);
     public void Unregister(ColorableSkinDrawable skinDrawable) => colorableDrawables.Remove(skinDrawable);
 
-    public void SetColor(int lane, Colour4 color)
+    public void SetColor(MapColor index, Colour4 color)
+    {
+        // Not implemented yet
+        colorableDrawables.ForEach(drawable =>
+        {
+            // Logger.Log($"{drawable.Index}");
+            if (drawable.Index == index)
+            {
+                drawable.SetColor(color);
+
+                switch (drawable.Index)
+                {
+                    case MapColor.Primary:
+                        Primary = color;
+                        break;
+
+                    case MapColor.Secondary:
+                        Secondary = color;
+                        break;
+
+                    case MapColor.Middle:
+                        Middle = color;
+                        break;
+                }
+            }
+        });
+        ColorChanged?.Invoke(color);
+    }
+
+    public void FadeColor(MapColor index, Colour4 color, double duration = 0, Easing easing = Easing.None)
     {
         // Not implemented yet
         ColorChanged?.Invoke(color);
     }
 
-    public void FadeColor(int lane, Colour4 color, double duration = 0, Easing easing = Easing.None)
+    public bool HasColorFor(int lane, int keyCount, out Colour4 colour)
     {
-        // Not implemented yet
-        ColorChanged?.Invoke(color);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        colour = GetColor(index, Colour4.Transparent);
+        return colour != Colour4.Transparent;
     }
 
-    public bool HasColorFor(int lane, int keyCount, out Colour4 colour) => mapColors.HasColorFor(lane, keyCount, out colour);
+    public Colour4 GetColor(int index, Colour4 fallback)
+    {
+        var colors = new[]
+        {
+            Colour4.Transparent,
+            Primary,
+            Secondary,
+            Middle
+        };
 
-    public Colour4 GetColor(int index, Colour4 fallback) => mapColors.GetColor(index, fallback);
+        if (index < 0 || index >= colors.Length)
+            return fallback;
+
+        var col = colors[index];
+
+        if (col == Colour4.Transparent)
+            return fallback;
+
+        return col;
+    }
 }

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -9,6 +9,7 @@ using fluXis.Screens.Gameplay.Ruleset.HitObjects;
 using fluXis.Screens.Gameplay.Ruleset.Playfields.UI;
 using fluXis.Screens.Gameplay.Ruleset.TimingLines;
 using fluXis.Skinning;
+using fluXis.Skinning.Default;
 using fluXis.Utils.Extensions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -105,7 +106,7 @@ public partial class Playfield : Container
 
         ColorManager = new ColorManager(this);
         LoadComponent(ColorManager);
-        dependencies.CacheAs(ColorManager);
+        dependencies.CacheAs<ICustomColorProvider>(ColorManager);
 
         dependencies.CacheAs(this);
         dependencies.CacheAs(HitManager = new HitObjectManager

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -104,7 +104,7 @@ public partial class Playfield : Container
             Padding = new MarginPadding { Bottom = skin.SkinJson.GetKeymode(RealmMap.KeyCount).ReceptorOffset }
         };
 
-        ColorManager = new ColorManager(this, dependencies);
+        ColorManager = new ColorManager(this, ruleset, dependencies);
         LoadComponent(ColorManager);
         dependencies.CacheAs<ICustomColorProvider>(ColorManager);
 
@@ -145,6 +145,7 @@ public partial class Playfield : Container
             new EventHandler<ShakeEvent>(MapEvents.ShakeEvents, shake => ruleset.ShakeTarget.Shake(Math.Max(shake.Duration, 0), shake.Magnitude))
         };
 
+        MapEvents.ColorFadeEvents.ForEach(e => e.Apply(this));
         MapEvents.LayerFadeEvents.ForEach(e => e.Apply(this));
         MapEvents.PlayfieldMoveEvents.ForEach(e => e.Apply(this));
         MapEvents.PlayfieldScaleEvents.ForEach(e => e.Apply(this));
@@ -155,6 +156,7 @@ public partial class Playfield : Container
     protected override void Update()
     {
         updatePositionScale();
+        ColorManager.Update();
         var newReceptorOffset = laneSwitchManager.ReceptorOffset;
 
         hitline.Y = -laneSwitchManager.HitPosition;

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -51,6 +51,7 @@ public partial class Playfield : Container
     public Stage Stage { get; private set; }
     public FillFlowContainer<Receptor> Receptors { get; private set; }
     public HitObjectManager HitManager { get; private set; }
+    public ColorManager ColorManager { get; private set; }
     public float HUDAlpha { get; set; } = 1f;
 
     public MapInfo MapInfo => ruleset.MapInfo;
@@ -101,6 +102,10 @@ public partial class Playfield : Container
             ChildrenEnumerable = Enumerable.Range(0, RealmMap.KeyCount).Select(i => new Receptor(i)),
             Padding = new MarginPadding { Bottom = skin.SkinJson.GetKeymode(RealmMap.KeyCount).ReceptorOffset }
         };
+
+        ColorManager = new ColorManager(this);
+        LoadComponent(ColorManager);
+        dependencies.CacheAs(ColorManager);
 
         dependencies.CacheAs(this);
         dependencies.CacheAs(HitManager = new HitObjectManager

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -104,7 +104,7 @@ public partial class Playfield : Container
             Padding = new MarginPadding { Bottom = skin.SkinJson.GetKeymode(RealmMap.KeyCount).ReceptorOffset }
         };
 
-        ColorManager = new ColorManager(this);
+        ColorManager = new ColorManager(this, dependencies);
         LoadComponent(ColorManager);
         dependencies.CacheAs<ICustomColorProvider>(ColorManager);
 

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -104,10 +104,6 @@ public partial class Playfield : Container
             Padding = new MarginPadding { Bottom = skin.SkinJson.GetKeymode(RealmMap.KeyCount).ReceptorOffset }
         };
 
-        ColorManager = new ColorManager(this, ruleset, dependencies);
-        LoadComponent(ColorManager);
-        dependencies.CacheAs<ICustomColorProvider>(ColorManager);
-
         dependencies.CacheAs(this);
         dependencies.CacheAs(HitManager = new HitObjectManager
         {
@@ -115,10 +111,14 @@ public partial class Playfield : Container
             Masking = true
         });
 
+        LoadComponent(ColorManager = new ColorManager());
+        dependencies.CacheAs<ICustomColorProvider>(ColorManager);
+
         var receptorsFirst = skin.SkinJson.GetKeymode(RealmMap.KeyCount).ReceptorsFirst;
 
         InternalChildren = new[]
         {
+            ColorManager,
             new LaneSwitchAlert(),
             Stage = new Stage(),
             new TimingLineManager(),
@@ -156,7 +156,6 @@ public partial class Playfield : Container
     protected override void Update()
     {
         updatePositionScale();
-        ColorManager.Update();
         var newReceptorOffset = laneSwitchManager.ReceptorOffset;
 
         hitline.Y = -laneSwitchManager.HitPosition;

--- a/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
+++ b/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
@@ -55,8 +55,8 @@ public partial class ColorableSkinDrawable : CompositeDrawable
     /// Not to be confused with <see cref="TransformableExtensions.FadeColour{T}(T, osu.Framework.Graphics.Colour.ColourInfo, double, Easing)" />
     /// </summary>
     /// <param name="color"></param>
-    public virtual void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None) { }
-    public virtual void FadeColorGradient(Colour4 color1, Colour4 color2, double duration = 0, Easing easing = Easing.None) { }
+    public virtual void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None) { }
+    public virtual void FadeColorGradient(Colour4 color1, Colour4 color2, double startTime, double duration = 0, Easing easing = Easing.None) { }
 
     protected Colour4 GetIndexOrFallback(int index, Colour4 fallback)
     {

--- a/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
+++ b/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
@@ -17,9 +17,18 @@ public partial class ColorableSkinDrawable : CompositeDrawable
 
     protected bool UseCustomColor { get; set; }
 
-    public ColorableSkinDrawable(SkinJson skinJson)
+    public int Index { get; private set; }
+
+    public ColorableSkinDrawable(SkinJson skinJson, int index)
     {
         SkinJson = skinJson;
+        Index = index;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        ColorProvider.Register(this);
     }
 
     public void UpdateColor(int lane, int keyCount) => Schedule(() =>
@@ -42,7 +51,7 @@ public partial class ColorableSkinDrawable : CompositeDrawable
     /// Not to be confused with <see cref="TransformableExtensions.FadeColour{T}(T, osu.Framework.Graphics.Colour.ColourInfo, double, Easing)" />
     /// </summary>
     /// <param name="color"></param>
-    public virtual void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None) {  }
+    public virtual void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None) { }
 
     protected Colour4 GetIndexOrFallback(int index, Colour4 fallback)
     {
@@ -52,5 +61,11 @@ public partial class ColorableSkinDrawable : CompositeDrawable
             return fallback;
 
         return col.Value;
+    }
+
+    protected override void Dispose(bool isDisposing)
+    {
+        ColorProvider.Unregister(this);
+        base.Dispose(isDisposing);
     }
 }

--- a/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
+++ b/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
@@ -1,3 +1,5 @@
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Screens.Gameplay.Ruleset.Playfields;
 using fluXis.Skinning.Default;
 using fluXis.Skinning.Json;
 using JetBrains.Annotations;
@@ -17,9 +19,9 @@ public partial class ColorableSkinDrawable : CompositeDrawable
 
     protected bool UseCustomColor { get; set; }
 
-    public int Index { get; private set; }
+    public MapColor Index { get; private set; }
 
-    public ColorableSkinDrawable(SkinJson skinJson, int index)
+    public ColorableSkinDrawable(SkinJson skinJson, MapColor index)
     {
         SkinJson = skinJson;
         Index = index;

--- a/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
+++ b/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
@@ -29,10 +29,8 @@ public partial class ColorableSkinDrawable : CompositeDrawable
     [BackgroundDependencyLoader]
     private void load()
     {
-        ColorProvider.Register(this);
+        RegisterToProvider();
     }
-
-    public void ResolveProviderFrom(DependencyContainer dependencies) => ColorProvider = dependencies.Get<ICustomColorProvider>();
 
     public void UpdateColor(int lane, int keyCount) => Schedule(() =>
     {
@@ -49,14 +47,10 @@ public partial class ColorableSkinDrawable : CompositeDrawable
     });
 
     public virtual void SetColor(Colour4 color) { }
-    public virtual void SetColorGradient(Colour4 color1, Colour4 color2) { }
+    public virtual void UpdateColor(MapColor index, Colour4 color) => SetColor(color);
 
-    /// <summary>
-    /// Not to be confused with <see cref="TransformableExtensions.FadeColour{T}(T, osu.Framework.Graphics.Colour.ColourInfo, double, Easing)" />
-    /// </summary>
-    /// <param name="color"></param>
-    public virtual void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None) { }
-    public virtual void FadeColorGradient(Colour4 color1, Colour4 color2, double startTime, double duration = 0, Easing easing = Easing.None) { }
+    protected virtual void RegisterToProvider() => ColorProvider?.Register(this, Index);
+    protected virtual void UnregisterFromProvider() => ColorProvider?.Unregister(this, Index);
 
     protected Colour4 GetIndexOrFallback(int index, Colour4 fallback)
     {
@@ -70,7 +64,7 @@ public partial class ColorableSkinDrawable : CompositeDrawable
 
     protected override void Dispose(bool isDisposing)
     {
-        ColorProvider.Unregister(this);
+        UnregisterFromProvider();
         base.Dispose(isDisposing);
     }
 }

--- a/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
+++ b/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
@@ -36,7 +36,13 @@ public partial class ColorableSkinDrawable : CompositeDrawable
         SetColor(SkinJson?.GetLaneColor(lane, keyCount) ?? Colour4.White);
     });
 
-    protected virtual void SetColor(Colour4 color) { }
+    public virtual void SetColor(Colour4 color) { }
+
+    /// <summary>
+    /// Not to be confused with <see cref="TransformableExtensions.FadeColour{T}(T, osu.Framework.Graphics.Colour.ColourInfo, double, Easing)" />
+    /// </summary>
+    /// <param name="color"></param>
+    public virtual void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None) {  }
 
     protected Colour4 GetIndexOrFallback(int index, Colour4 fallback)
     {

--- a/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
+++ b/fluXis/Skinning/Bases/ColorableSkinDrawable.cs
@@ -1,5 +1,4 @@
 using fluXis.Graphics.UserInterface.Color;
-using fluXis.Screens.Gameplay.Ruleset.Playfields;
 using fluXis.Skinning.Default;
 using fluXis.Skinning.Json;
 using JetBrains.Annotations;
@@ -33,6 +32,8 @@ public partial class ColorableSkinDrawable : CompositeDrawable
         ColorProvider.Register(this);
     }
 
+    public void ResolveProviderFrom(DependencyContainer dependencies) => ColorProvider = dependencies.Get<ICustomColorProvider>();
+
     public void UpdateColor(int lane, int keyCount) => Schedule(() =>
     {
         if (UseCustomColor)
@@ -48,12 +49,14 @@ public partial class ColorableSkinDrawable : CompositeDrawable
     });
 
     public virtual void SetColor(Colour4 color) { }
+    public virtual void SetColorGradient(Colour4 color1, Colour4 color2) { }
 
     /// <summary>
     /// Not to be confused with <see cref="TransformableExtensions.FadeColour{T}(T, osu.Framework.Graphics.Colour.ColourInfo, double, Easing)" />
     /// </summary>
     /// <param name="color"></param>
     public virtual void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None) { }
+    public virtual void FadeColorGradient(Colour4 color1, Colour4 color2, double duration = 0, Easing easing = Easing.None) { }
 
     protected Colour4 GetIndexOrFallback(int index, Colour4 fallback)
     {

--- a/fluXis/Skinning/Custom/CustomSkin.cs
+++ b/fluXis/Skinning/Custom/CustomSkin.cs
@@ -173,7 +173,7 @@ public class CustomSkin : ISkin
         if (storage.Exists(path))
         {
             var index = Theme.GetLaneColorIndex(lane, keyCount);
-            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), index, keyCount, false);
+            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), (MapColor)index, keyCount, false);
             drawable.UpdateColor(lane, keyCount);
             return drawable;
         }
@@ -207,7 +207,7 @@ public class CustomSkin : ISkin
         if (storage.Exists(path))
         {
             var index = Theme.GetLaneColorIndex(lane, keyCount);
-            var drawable = new CustomHitObjectBody(SkinJson, index, keyCount, textures.Get(path));
+            var drawable = new CustomHitObjectBody(SkinJson, (MapColor)index, keyCount, textures.Get(path));
             drawable.UpdateColor(lane, keyCount);
             return drawable;
         }
@@ -222,7 +222,7 @@ public class CustomSkin : ISkin
         if (storage.Exists(path))
         {
             var index = Theme.GetLaneColorIndex(lane, keyCount);
-            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), index, keyCount, true);
+            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), (MapColor)index, keyCount, true);
             drawable.UpdateColor(lane, keyCount);
             return drawable;
         }

--- a/fluXis/Skinning/Custom/CustomSkin.cs
+++ b/fluXis/Skinning/Custom/CustomSkin.cs
@@ -10,6 +10,7 @@ using fluXis.Skinning.Custom.Health;
 using fluXis.Skinning.Custom.HitObjects;
 using fluXis.Skinning.Custom.Judgements;
 using fluXis.Skinning.Custom.Lighting;
+using fluXis.Skinning.Custom.Receptor;
 using fluXis.Skinning.Json;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
@@ -251,13 +252,7 @@ public class CustomSkin : ISkin
         if (storage.Exists(path))
         {
             var index = Theme.GetLaneColorIndex(lane, keyCount);
-            return new SkinnableSprite(textures.Get(path), index)
-            {
-                Anchor = Anchor.BottomCentre,
-                Origin = Anchor.BottomCentre,
-                RelativeSizeAxes = Axes.X,
-                Width = 1
-            };
+            return new CustomReceptor(SkinJson, textures.Get(path), (MapColor)index, keyCount);
         }
 
         return null;

--- a/fluXis/Skinning/Custom/CustomSkin.cs
+++ b/fluXis/Skinning/Custom/CustomSkin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using fluXis.Audio;
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Scoring.Enums;
 using fluXis.Scoring.Processing.Health;
 using fluXis.Screens.Course;
@@ -171,7 +172,8 @@ public class CustomSkin : ISkin
 
         if (storage.Exists(path))
         {
-            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), keyCount, false);
+            var index = Theme.GetLaneColorIndex(lane, keyCount);
+            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), index, keyCount, false);
             drawable.UpdateColor(lane, keyCount);
             return drawable;
         }
@@ -204,7 +206,8 @@ public class CustomSkin : ISkin
 
         if (storage.Exists(path))
         {
-            var drawable = new CustomHitObjectBody(SkinJson, keyCount, textures.Get(path));
+            var index = Theme.GetLaneColorIndex(lane, keyCount);
+            var drawable = new CustomHitObjectBody(SkinJson, index, keyCount, textures.Get(path));
             drawable.UpdateColor(lane, keyCount);
             return drawable;
         }
@@ -218,7 +221,8 @@ public class CustomSkin : ISkin
 
         if (storage.Exists(path))
         {
-            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), keyCount, true);
+            var index = Theme.GetLaneColorIndex(lane, keyCount);
+            var drawable = new CustomHitObjectPiece(SkinJson, textures.Get(path), index, keyCount, true);
             drawable.UpdateColor(lane, keyCount);
             return drawable;
         }
@@ -246,9 +250,9 @@ public class CustomSkin : ISkin
 
         if (storage.Exists(path))
         {
-            return new SkinnableSprite
+            var index = Theme.GetLaneColorIndex(lane, keyCount);
+            return new SkinnableSprite(textures.Get(path), index)
             {
-                Texture = textures.Get(path),
                 Anchor = Anchor.BottomCentre,
                 Origin = Anchor.BottomCentre,
                 RelativeSizeAxes = Axes.X,

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Bases.HitObjects;
 using fluXis.Skinning.Json;
@@ -14,7 +15,7 @@ public partial class CustomHitObjectBody : ColorableSkinDrawable, ICanHaveSnapCo
     private int mode { get; }
     private Drawable sprite { get; }
 
-    public CustomHitObjectBody(SkinJson skinJson, int index, int mode, Texture texture)
+    public CustomHitObjectBody(SkinJson skinJson, MapColor index, int mode, Texture texture)
         : base(skinJson, index)
     {
         this.mode = mode;

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
@@ -30,7 +30,7 @@ public partial class CustomHitObjectBody : ColorableSkinDrawable, ICanHaveSnapCo
         };
     }
 
-    protected override void SetColor(Colour4 color)
+    public override void SetColor(Colour4 color)
     {
         var keymode = SkinJson.GetKeymode(mode);
 
@@ -38,6 +38,16 @@ public partial class CustomHitObjectBody : ColorableSkinDrawable, ICanHaveSnapCo
             return;
 
         sprite.Colour = color;
+    }
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+    { 
+        var keymode = SkinJson.GetKeymode(mode);
+
+        if (!keymode.TintNotes || !keymode.TintLongNotes)
+            return;
+
+        sprite.FadeColour(color, duration, easing);
     }
 
     public void ApplySnapColor(int start, int end)

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
@@ -41,14 +41,15 @@ public partial class CustomHitObjectBody : ColorableSkinDrawable, ICanHaveSnapCo
         sprite.Colour = color;
     }
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-    { 
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
         var keymode = SkinJson.GetKeymode(mode);
 
         if (!keymode.TintNotes || !keymode.TintLongNotes)
             return;
 
-        sprite.FadeColour(color, duration, easing);
+        using (BeginAbsoluteSequence(startTime))
+            sprite.FadeColour(color, duration, easing);
     }
 
     public void ApplySnapColor(int start, int end)

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
@@ -41,17 +41,6 @@ public partial class CustomHitObjectBody : ColorableSkinDrawable, ICanHaveSnapCo
         sprite.Colour = color;
     }
 
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        var keymode = SkinJson.GetKeymode(mode);
-
-        if (!keymode.TintNotes || !keymode.TintLongNotes)
-            return;
-
-        using (BeginAbsoluteSequence(startTime))
-            sprite.FadeColour(color, duration, easing);
-    }
-
     public void ApplySnapColor(int start, int end)
     {
         var keymode = SkinJson.GetKeymode(mode);

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectBody.cs
@@ -14,8 +14,8 @@ public partial class CustomHitObjectBody : ColorableSkinDrawable, ICanHaveSnapCo
     private int mode { get; }
     private Drawable sprite { get; }
 
-    public CustomHitObjectBody(SkinJson skinJson, int mode, Texture texture)
-        : base(skinJson)
+    public CustomHitObjectBody(SkinJson skinJson, int index, int mode, Texture texture)
+        : base(skinJson, index)
     {
         this.mode = mode;
 

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
@@ -44,7 +44,7 @@ public partial class CustomHitObjectPiece : ColorableSkinDrawable, ICanHaveSnapC
         sprite.Colour = color;
     }
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
     { 
         var keymode = SkinJson.GetKeymode(mode);
 

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
@@ -12,8 +12,8 @@ public partial class CustomHitObjectPiece : ColorableSkinDrawable, ICanHaveSnapC
     private bool isEnd { get; }
     private Drawable sprite { get; }
 
-    public CustomHitObjectPiece(SkinJson skinJson, Texture texture, int mode, bool end)
-        : base(skinJson)
+    public CustomHitObjectPiece(SkinJson skinJson, Texture texture, int index, int mode, bool end)
+        : base(skinJson, index)
     {
         this.mode = mode;
         isEnd = end;

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
@@ -30,7 +30,7 @@ public partial class CustomHitObjectPiece : ColorableSkinDrawable, ICanHaveSnapC
         };
     }
 
-    protected override void SetColor(Colour4 color)
+    public override void SetColor(Colour4 color)
     {
         var keymode = SkinJson.GetKeymode(mode);
 
@@ -41,6 +41,19 @@ public partial class CustomHitObjectPiece : ColorableSkinDrawable, ICanHaveSnapC
             return;
 
         sprite.Colour = color;
+    }
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+    { 
+        var keymode = SkinJson.GetKeymode(mode);
+
+        if (!keymode.TintNotes)
+            return;
+
+        if (isEnd && !keymode.TintLongNotes)
+            return;
+
+        sprite.FadeColour(color, duration, easing);
     }
 
     public void ApplySnapColor(int start, int end)

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Bases.HitObjects;
 using fluXis.Skinning.Json;
@@ -12,7 +13,7 @@ public partial class CustomHitObjectPiece : ColorableSkinDrawable, ICanHaveSnapC
     private bool isEnd { get; }
     private Drawable sprite { get; }
 
-    public CustomHitObjectPiece(SkinJson skinJson, Texture texture, int index, int mode, bool end)
+    public CustomHitObjectPiece(SkinJson skinJson, Texture texture, MapColor index, int mode, bool end)
         : base(skinJson, index)
     {
         this.mode = mode;

--- a/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
+++ b/fluXis/Skinning/Custom/HitObjects/CustomHitObjectPiece.cs
@@ -44,19 +44,6 @@ public partial class CustomHitObjectPiece : ColorableSkinDrawable, ICanHaveSnapC
         sprite.Colour = color;
     }
 
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    { 
-        var keymode = SkinJson.GetKeymode(mode);
-
-        if (!keymode.TintNotes)
-            return;
-
-        if (isEnd && !keymode.TintLongNotes)
-            return;
-
-        sprite.FadeColour(color, duration, easing);
-    }
-
     public void ApplySnapColor(int start, int end)
     {
         UseCustomColor = true;

--- a/fluXis/Skinning/Custom/Receptor/CustomReceptor.cs
+++ b/fluXis/Skinning/Custom/Receptor/CustomReceptor.cs
@@ -55,7 +55,7 @@ public partial class CustomReceptor : ColorableSkinDrawable
     {
         var keymode = SkinJson.GetKeymode(mode);
 
-        if (!keymode.TintNotes)
+        if (!keymode.TintReceptors)
             return;
 
         Sprite.Colour = color;

--- a/fluXis/Skinning/Custom/Receptor/CustomReceptor.cs
+++ b/fluXis/Skinning/Custom/Receptor/CustomReceptor.cs
@@ -1,0 +1,89 @@
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Bases;
+using fluXis.Skinning.Json;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace fluXis.Skinning.Custom.Receptor;
+
+public partial class CustomReceptor : ColorableSkinDrawable
+{
+    private int mode { get; }
+    public bool SkipResizing { get; set; }
+
+    protected Sprite Sprite { get; }
+
+    public CustomReceptor(SkinJson skinJson, Texture texture, MapColor index, int mode)
+        : base(skinJson, index)
+    {
+        this.mode = mode;
+
+        RelativeSizeAxes = Axes.Both;
+
+        InternalChild = Sprite = new Sprite
+        {
+            Texture = texture,
+            Anchor = Anchor.BottomCentre,
+            Origin = Anchor.BottomCentre,
+            RelativeSizeAxes = Axes.X,
+            Width = 1,
+        };
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        switch (Index)
+        {
+            case MapColor.Primary:
+                SetColor(ColorProvider.Primary);
+                break;
+
+            case MapColor.Secondary:
+                SetColor(ColorProvider.Secondary);
+                break;
+
+            case MapColor.Middle:
+                SetColor(ColorProvider.Middle);
+                break;
+        }
+    }
+
+    public override void SetColor(Colour4 color)
+    {
+        var keymode = SkinJson.GetKeymode(mode);
+
+        if (!keymode.TintNotes)
+            return;
+
+        Sprite.Colour = color;
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        Sprite.Height = Sprite.DrawWidth;
+
+        if (SkipResizing)
+            return;
+
+        var receptorTexture = Sprite.Texture;
+
+        if (receptorTexture != null)
+        {
+            switch (Sprite.RelativeSizeAxes)
+            {
+                case Axes.X:
+                    Sprite.Height = DrawWidth / receptorTexture.DisplayWidth * receptorTexture.DisplayHeight;
+                    break;
+
+                case Axes.Y:
+                    Sprite.Width = DrawHeight / receptorTexture.DisplayHeight * receptorTexture.DisplayWidth;
+                    break;
+            }
+        }
+    }
+}

--- a/fluXis/Skinning/Default/DefaultSkin.cs
+++ b/fluXis/Skinning/Default/DefaultSkin.cs
@@ -113,7 +113,7 @@ public class DefaultSkin : ISkin
     public virtual Drawable GetHitObject(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var piece = new DefaultHitObjectPiece(SkinJson, index);
+        var piece = new DefaultHitObjectPiece(SkinJson, (MapColor)index);
         piece.UpdateColor(lane, keyCount);
         return piece;
     }
@@ -123,7 +123,7 @@ public class DefaultSkin : ISkin
     public virtual Drawable GetLongNoteBody(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var body = new DefaultHitObjectBody(SkinJson, index);
+        var body = new DefaultHitObjectBody(SkinJson, (MapColor)index);
         body.UpdateColor(lane, keyCount);
         return body;
     }
@@ -131,7 +131,7 @@ public class DefaultSkin : ISkin
     public virtual Drawable GetLongNoteEnd(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var end = new DefaultHitObjectEnd(SkinJson, index);
+        var end = new DefaultHitObjectEnd(SkinJson, (MapColor)index);
         end.UpdateColor(lane, keyCount);
         return end;
     }
@@ -146,7 +146,7 @@ public class DefaultSkin : ISkin
     public virtual Drawable GetReceptor(int lane, int keyCount, bool down)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var receptor = down ? new DefaultReceptorDown(SkinJson, index) : new DefaultReceptorUp(SkinJson, index);
+        var receptor = down ? new DefaultReceptorDown(SkinJson, (MapColor)index) : new DefaultReceptorUp(SkinJson, (MapColor)index);
         receptor.UpdateColor(lane, keyCount);
         receptor.Height = SkinJson.GetKeymode(keyCount).HitPosition;
         return receptor;

--- a/fluXis/Skinning/Default/DefaultSkin.cs
+++ b/fluXis/Skinning/Default/DefaultSkin.cs
@@ -1,5 +1,6 @@
 using System;
 using fluXis.Audio;
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Scoring.Enums;
 using fluXis.Scoring.Processing.Health;
 using fluXis.Screens.Course;
@@ -111,7 +112,8 @@ public class DefaultSkin : ISkin
 
     public virtual Drawable GetHitObject(int lane, int keyCount)
     {
-        var piece = new DefaultHitObjectPiece(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var piece = new DefaultHitObjectPiece(SkinJson, index);
         piece.UpdateColor(lane, keyCount);
         return piece;
     }
@@ -120,14 +122,16 @@ public class DefaultSkin : ISkin
 
     public virtual Drawable GetLongNoteBody(int lane, int keyCount)
     {
-        var body = new DefaultHitObjectBody(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var body = new DefaultHitObjectBody(SkinJson, index);
         body.UpdateColor(lane, keyCount);
         return body;
     }
 
     public virtual Drawable GetLongNoteEnd(int lane, int keyCount)
     {
-        var end = new DefaultHitObjectEnd(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var end = new DefaultHitObjectEnd(SkinJson, index);
         end.UpdateColor(lane, keyCount);
         return end;
     }
@@ -141,7 +145,8 @@ public class DefaultSkin : ISkin
 
     public virtual Drawable GetReceptor(int lane, int keyCount, bool down)
     {
-        var receptor = down ? new DefaultReceptorDown(SkinJson) : new DefaultReceptorUp(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var receptor = down ? new DefaultReceptorDown(SkinJson, index) : new DefaultReceptorUp(SkinJson, index);
         receptor.UpdateColor(lane, keyCount);
         receptor.Height = SkinJson.GetKeymode(keyCount).HitPosition;
         return receptor;

--- a/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
+++ b/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
@@ -24,7 +24,7 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
     private double drainRate;
 
     public DefaultHealthBar(SkinJson skinJson, HealthProcessor processor)
-        : base(skinJson, -1)
+        : base(skinJson, MapColor.Other)
     {
         Debug.Assert(processor != null);
         this.processor = processor;

--- a/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
+++ b/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
@@ -9,7 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Logging;
 using osu.Framework.Utils;
 using osuTK;
 
@@ -61,8 +60,12 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
 
     public override void SetColorGradient(Colour4 color1, Colour4 color2) => BorderColour = ColourInfo.GradientVertical(color1, color2);
 
-    public override void FadeColorGradient(Colour4 color1, Colour4 color2, double duration = 0, Easing easing = Easing.None)
-        => this.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(color1, color2), duration, easing);
+    public override void FadeColorGradient(Colour4 color1, Colour4 color2, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            this.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(color1, color2), duration, easing);
+    }
+    
 
     protected override void Update()
     {

--- a/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
+++ b/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
@@ -24,7 +24,7 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
     private double drainRate;
 
     public DefaultHealthBar(SkinJson skinJson, HealthProcessor processor)
-        : base(skinJson)
+        : base(skinJson, -1)
     {
         Debug.Assert(processor != null);
         this.processor = processor;

--- a/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
+++ b/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Logging;
 using osu.Framework.Utils;
 using osuTK;
 
@@ -24,7 +25,7 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
     private double drainRate;
 
     public DefaultHealthBar(SkinJson skinJson, HealthProcessor processor)
-        : base(skinJson, MapColor.Other)
+        : base(skinJson, MapColor.Gradient)
     {
         Debug.Assert(processor != null);
         this.processor = processor;
@@ -56,7 +57,14 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
                 Y = 10
             }
         };
+
+        ColorProvider.Register(this);
     }
+
+    public override void SetColorGradient(Colour4 color1, Colour4 color2) => BorderColour = ColourInfo.GradientVertical(color1, color2);
+
+    public override void FadeColorGradient(Colour4 color1, Colour4 color2, double duration = 0, Easing easing = Easing.None)
+        => this.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(color1, color2), duration, easing);
 
     protected override void Update()
     {
@@ -77,5 +85,11 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
                 BorderColour = text.Colour = drainGradient.Interpolate(new Vector2(1 - (Math.Clamp((float)drainRate, -.2f, .2f) + .2f) / .4f, 0));
                 break;
         }
+    }
+
+    protected override void Dispose(bool isDisposing)
+    {
+        ColorProvider.Unregister(this);
+        base.Dispose(isDisposing);
     }
 }

--- a/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
+++ b/fluXis/Skinning/Default/Health/DefaultHealthBar.cs
@@ -57,8 +57,6 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
                 Y = 10
             }
         };
-
-        ColorProvider.Register(this);
     }
 
     public override void SetColorGradient(Colour4 color1, Colour4 color2) => BorderColour = ColourInfo.GradientVertical(color1, color2);
@@ -85,11 +83,5 @@ public partial class DefaultHealthBar : ColorableSkinDrawable
                 BorderColour = text.Colour = drainGradient.Interpolate(new Vector2(1 - (Math.Clamp((float)drainRate, -.2f, .2f) + .2f) / .4f, 0));
                 break;
         }
-    }
-
-    protected override void Dispose(bool isDisposing)
-    {
-        ColorProvider.Unregister(this);
-        base.Dispose(isDisposing);
     }
 }

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
@@ -9,8 +9,8 @@ namespace fluXis.Skinning.Default.HitObject;
 
 public partial class DefaultHitObjectBody : ColorableSkinDrawable, ICanHaveSnapColor
 {
-    public DefaultHitObjectBody(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultHitObjectBody(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;
         Width = 0.9f;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
@@ -26,11 +26,6 @@ public partial class DefaultHitObjectBody : ColorableSkinDrawable, ICanHaveSnapC
 
     public override void SetColor(Colour4 color)
         => Colour = color;
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            this.FadeColour(color, duration, easing);
-    }
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
@@ -23,8 +23,11 @@ public partial class DefaultHitObjectBody : ColorableSkinDrawable, ICanHaveSnapC
         };
     }
 
-    protected override void SetColor(Colour4 color)
+    public override void SetColor(Colour4 color)
         => Colour = color;
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => this.FadeColour(color, duration, easing);
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
@@ -26,9 +26,11 @@ public partial class DefaultHitObjectBody : ColorableSkinDrawable, ICanHaveSnapC
 
     public override void SetColor(Colour4 color)
         => Colour = color;
-
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => this.FadeColour(color, duration, easing);
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            this.FadeColour(color, duration, easing);
+    }
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectBody.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Bases.HitObjects;
 using fluXis.Skinning.Json;
@@ -9,7 +10,7 @@ namespace fluXis.Skinning.Default.HitObject;
 
 public partial class DefaultHitObjectBody : ColorableSkinDrawable, ICanHaveSnapColor
 {
-    public DefaultHitObjectBody(SkinJson skinJson, int index)
+    public DefaultHitObjectBody(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
@@ -34,12 +34,6 @@ public partial class DefaultHitObjectEnd : ColorableSkinDrawable, ICanHaveSnapCo
 
     public override void SetColor(Colour4 color) => box.Colour = color.Darken(.4f);
 
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            box.FadeColour(color.Darken(.4f), duration, easing);
-    }
-
     public void ApplySnapColor(int start, int end)
     {
         UseCustomColor = true;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
@@ -34,8 +34,11 @@ public partial class DefaultHitObjectEnd : ColorableSkinDrawable, ICanHaveSnapCo
 
     public override void SetColor(Colour4 color) => box.Colour = color.Darken(.4f);
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => box.FadeColour(color.Darken(.4f), duration, easing);
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            box.FadeColour(color.Darken(.4f), duration, easing);
+    }
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Bases.HitObjects;
 using fluXis.Skinning.Json;
@@ -10,7 +11,7 @@ public partial class DefaultHitObjectEnd : ColorableSkinDrawable, ICanHaveSnapCo
 {
     private readonly Box box;
 
-    public DefaultHitObjectEnd(SkinJson skinJson, int index)
+    public DefaultHitObjectEnd(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         CornerRadius = 10;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
@@ -10,8 +10,8 @@ public partial class DefaultHitObjectEnd : ColorableSkinDrawable, ICanHaveSnapCo
 {
     private readonly Box box;
 
-    public DefaultHitObjectEnd(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultHitObjectEnd(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         CornerRadius = 10;
         Masking = true;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectEnd.cs
@@ -31,7 +31,10 @@ public partial class DefaultHitObjectEnd : ColorableSkinDrawable, ICanHaveSnapCo
         Height = 42f * factor;
     }
 
-    protected override void SetColor(Colour4 color) => box.Colour = color.Darken(.4f);
+    public override void SetColor(Colour4 color) => box.Colour = color.Darken(.4f);
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => box.FadeColour(color.Darken(.4f), duration, easing);
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
@@ -34,12 +34,6 @@ public partial class DefaultHitObjectPiece : ColorableSkinDrawable, ICanHaveSnap
 
     public override void SetColor(Colour4 color) => box.Colour = color;
 
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            box.FadeColour(color, duration, easing);
-    }
-
     public void ApplySnapColor(int start, int end)
     {
         UseCustomColor = true;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
@@ -10,8 +10,8 @@ public partial class DefaultHitObjectPiece : ColorableSkinDrawable, ICanHaveSnap
 {
     private readonly Box box;
 
-    public DefaultHitObjectPiece(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultHitObjectPiece(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         CornerRadius = 10;
         Masking = true;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Bases.HitObjects;
 using fluXis.Skinning.Json;
@@ -10,7 +11,7 @@ public partial class DefaultHitObjectPiece : ColorableSkinDrawable, ICanHaveSnap
 {
     private readonly Box box;
 
-    public DefaultHitObjectPiece(SkinJson skinJson, int index)
+    public DefaultHitObjectPiece(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         CornerRadius = 10;

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
@@ -34,8 +34,11 @@ public partial class DefaultHitObjectPiece : ColorableSkinDrawable, ICanHaveSnap
 
     public override void SetColor(Colour4 color) => box.Colour = color;
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => box.FadeColour(color, duration, easing);
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            box.FadeColour(color, duration, easing);
+    }
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
+++ b/fluXis/Skinning/Default/HitObject/DefaultHitObjectPiece.cs
@@ -31,7 +31,10 @@ public partial class DefaultHitObjectPiece : ColorableSkinDrawable, ICanHaveSnap
         Height = 42f * factor;
     }
 
-    protected override void SetColor(Colour4 color) => box.Colour = color;
+    public override void SetColor(Colour4 color) => box.Colour = color;
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => box.FadeColour(color, duration, easing);
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/Default/ICustomColorProvider.cs
+++ b/fluXis/Skinning/Default/ICustomColorProvider.cs
@@ -1,3 +1,4 @@
+using fluXis.Skinning.Bases;
 using osu.Framework.Graphics;
 
 namespace fluXis.Skinning.Default;
@@ -10,4 +11,7 @@ public interface ICustomColorProvider
 
     bool HasColorFor(int lane, int keyCount, out Colour4 colour);
     Colour4 GetColor(int index, Colour4 fallback);
+
+    void Register(ColorableSkinDrawable skinDrawable) { }
+    void Unregister(ColorableSkinDrawable skinDrawable) { }
 }

--- a/fluXis/Skinning/Default/ICustomColorProvider.cs
+++ b/fluXis/Skinning/Default/ICustomColorProvider.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using osu.Framework.Graphics;
 
@@ -12,6 +13,6 @@ public interface ICustomColorProvider
     bool HasColorFor(int lane, int keyCount, out Colour4 colour);
     Colour4 GetColor(int index, Colour4 fallback);
 
-    void Register(ColorableSkinDrawable skinDrawable) { }
-    void Unregister(ColorableSkinDrawable skinDrawable) { }
+    void Register(ColorableSkinDrawable draw, MapColor index) { }
+    void Unregister(ColorableSkinDrawable draw, MapColor index) { }
 }

--- a/fluXis/Skinning/Default/Lighting/DefaultColumnLighting.cs
+++ b/fluXis/Skinning/Default/Lighting/DefaultColumnLighting.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Json;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -16,6 +17,8 @@ public partial class DefaultColumnLighting : VisibilityContainer
     [Resolved(CanBeNull = true)]
     private ICustomColorProvider colorProvider { get; set; }
 
+    private MapColor index;
+
     public DefaultColumnLighting(SkinJson skinJson)
     {
         this.skinJson = skinJson;
@@ -31,6 +34,7 @@ public partial class DefaultColumnLighting : VisibilityContainer
             new Box
             {
                 RelativeSizeAxes = Axes.Both,
+                Colour = ColourInfo.GradientVertical(Colour4.White.Opacity(0), Colour4.White),
                 Alpha = .5f
             }
         };
@@ -41,9 +45,27 @@ public partial class DefaultColumnLighting : VisibilityContainer
         if (colorProvider == null || !colorProvider.HasColorFor(lane, maxLanes, out var color))
             color = skinJson.GetLaneColor(lane, maxLanes);
 
-        Colour = ColourInfo.GradientVertical(color.Opacity(0), color);
+        Colour = color;
+        index = (MapColor)Theme.GetLaneColorIndex(lane, maxLanes);
     });
 
     protected override void PopIn() => this.FadeIn();
     protected override void PopOut() => this.FadeOut(300, Easing.Out);
+
+    protected override void Update()
+    {
+        base.Update();
+
+        if (colorProvider is null) return;
+
+        // kinda dumb but it's the best way of doing this
+        // without having to rewrite this to not use a visibility container
+        Colour = index switch
+        {
+            MapColor.Primary => colorProvider.Primary,
+            MapColor.Secondary => colorProvider.Secondary,
+            MapColor.Middle => colorProvider.Middle,
+            _ => Colour
+        };
+    }
 }

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
@@ -13,6 +13,9 @@ public partial class DefaultReceptorDown : DefaultReceptorUp
 
     public override void SetColor(Colour4 color) => Diamond.BorderColour = color;
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => Diamond.TransformTo(nameof(Diamond.BorderColour), color, duration, easing);
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            Diamond.TransformTo(nameof(Diamond.BorderColour), color, duration, easing);
+    }
 }

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
@@ -10,5 +10,8 @@ public partial class DefaultReceptorDown : DefaultReceptorUp
     {
     }
 
-    protected override void SetColor(Colour4 color) => Diamond.BorderColour = color;
+    public override void SetColor(Colour4 color) => Diamond.BorderColour = color;
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => Diamond.TransformTo(nameof(Diamond.BorderColour), color, duration, easing);
 }

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
@@ -1,3 +1,4 @@
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Json;
 using osu.Framework.Graphics;
 
@@ -5,7 +6,7 @@ namespace fluXis.Skinning.Default.Receptor;
 
 public partial class DefaultReceptorDown : DefaultReceptorUp
 {
-    public DefaultReceptorDown(SkinJson skinJson, int index)
+    public DefaultReceptorDown(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
     }

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
@@ -5,8 +5,8 @@ namespace fluXis.Skinning.Default.Receptor;
 
 public partial class DefaultReceptorDown : DefaultReceptorUp
 {
-    public DefaultReceptorDown(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultReceptorDown(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
     }
 

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorDown.cs
@@ -12,10 +12,4 @@ public partial class DefaultReceptorDown : DefaultReceptorUp
     }
 
     public override void SetColor(Colour4 color) => Diamond.BorderColour = color;
-
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            Diamond.TransformTo(nameof(Diamond.BorderColour), color, duration, easing);
-    }
 }

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorUp.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorUp.cs
@@ -12,8 +12,8 @@ public partial class DefaultReceptorUp : ColorableSkinDrawable
 {
     protected Container Diamond { get; }
 
-    public DefaultReceptorUp(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultReceptorUp(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;
         Anchor = Anchor.BottomCentre;

--- a/fluXis/Skinning/Default/Receptor/DefaultReceptorUp.cs
+++ b/fluXis/Skinning/Default/Receptor/DefaultReceptorUp.cs
@@ -12,7 +12,7 @@ public partial class DefaultReceptorUp : ColorableSkinDrawable
 {
     protected Container Diamond { get; }
 
-    public DefaultReceptorUp(SkinJson skinJson, int index)
+    public DefaultReceptorUp(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;

--- a/fluXis/Skinning/Default/Stage/DefaultHitLine.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultHitLine.cs
@@ -11,7 +11,7 @@ namespace fluXis.Skinning.Default.Stage;
 public partial class DefaultHitLine : ColorableSkinDrawable
 {
     public DefaultHitLine(SkinJson skinJson)
-        : base(skinJson)
+        : base(skinJson, -1)
     {
     }
 

--- a/fluXis/Skinning/Default/Stage/DefaultHitLine.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultHitLine.cs
@@ -10,8 +10,12 @@ namespace fluXis.Skinning.Default.Stage;
 
 public partial class DefaultHitLine : ColorableSkinDrawable
 {
+    private Colour4 left; // secondary
+    private Colour4 right; // primary
+    private bool updateColors;
+
     public DefaultHitLine(SkinJson skinJson)
-        : base(skinJson, MapColor.Other)
+        : base(skinJson, MapColor.Accent)
     {
     }
 
@@ -21,11 +25,50 @@ public partial class DefaultHitLine : ColorableSkinDrawable
         Anchor = Anchor.BottomCentre;
         Origin = Anchor.TopCentre;
         Height = 3;
-        Colour = ColourInfo.GradientHorizontal(GetIndexOrFallback(1, Theme.Secondary), GetIndexOrFallback(2, Theme.Primary));
+        Colour = ColourInfo.GradientHorizontal(left = GetIndexOrFallback(1, Theme.Secondary), right = GetIndexOrFallback(2, Theme.Primary));
 
         InternalChild = new Box
         {
             RelativeSizeAxes = Axes.Both
         };
+    }
+
+    protected override void RegisterToProvider()
+    {
+        ColorProvider?.Register(this, MapColor.Primary);
+        ColorProvider?.Register(this, MapColor.Secondary);
+    }
+
+    protected override void UnregisterFromProvider()
+    {
+        ColorProvider?.Unregister(this, MapColor.Primary);
+        ColorProvider?.Unregister(this, MapColor.Secondary);
+    }
+
+    public override void UpdateColor(MapColor index, Colour4 color)
+    {
+        switch (index)
+        {
+            case MapColor.Primary:
+                left = color;
+                break;
+
+            case MapColor.Secondary:
+                right = color;
+                break;
+        }
+
+        updateColors = true;
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        if (!updateColors)
+            return;
+
+        Colour = ColourInfo.GradientHorizontal(left, right);
+        updateColors = false;
     }
 }

--- a/fluXis/Skinning/Default/Stage/DefaultHitLine.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultHitLine.cs
@@ -11,7 +11,7 @@ namespace fluXis.Skinning.Default.Stage;
 public partial class DefaultHitLine : ColorableSkinDrawable
 {
     public DefaultHitLine(SkinJson skinJson)
-        : base(skinJson, -1)
+        : base(skinJson, MapColor.Other)
     {
     }
 

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
@@ -12,7 +12,7 @@ public partial class DefaultStageBorderLeft : ColorableSkinDrawable
     private Box border;
 
     public DefaultStageBorderLeft(SkinJson skinJson)
-        : base(skinJson, MapColor.Secondary)
+        : base(skinJson, MapColor.Primary)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;
@@ -40,10 +40,4 @@ public partial class DefaultStageBorderLeft : ColorableSkinDrawable
     }
 
     public override void SetColor(Colour4 color) => border.Colour = color;
-
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            border.FadeColour(color, duration, easing);
-    }
 }

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
@@ -40,6 +40,10 @@ public partial class DefaultStageBorderLeft : ColorableSkinDrawable
     }
 
     public override void SetColor(Colour4 color) => border.Colour = color;
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => border.FadeColour(color, duration, easing);
+
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            border.FadeColour(color, duration, easing);
+    }
 }

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
@@ -10,7 +10,7 @@ namespace fluXis.Skinning.Default.Stage;
 public partial class DefaultStageBorderLeft : ColorableSkinDrawable
 {
     public DefaultStageBorderLeft(SkinJson skinJson)
-        : base(skinJson)
+        : base(skinJson, 1)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
@@ -9,8 +9,10 @@ namespace fluXis.Skinning.Default.Stage;
 
 public partial class DefaultStageBorderLeft : ColorableSkinDrawable
 {
+    private Box border;
+
     public DefaultStageBorderLeft(SkinJson skinJson)
-        : base(skinJson, MapColor.Primary)
+        : base(skinJson, MapColor.Secondary)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;
@@ -28,7 +30,7 @@ public partial class DefaultStageBorderLeft : ColorableSkinDrawable
                 Margin = new MarginPadding { Left = DefaultSkin.BORDER_COLOR },
                 Colour = Theme.Background3
             },
-            new Box
+            border = new Box
             {
                 RelativeSizeAxes = Axes.Y,
                 Width = DefaultSkin.BORDER_COLOR,
@@ -36,4 +38,8 @@ public partial class DefaultStageBorderLeft : ColorableSkinDrawable
             }
         };
     }
+
+    public override void SetColor(Colour4 color) => border.Colour = color;
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => border.FadeColour(color, duration, easing);
 }

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderLeft.cs
@@ -10,7 +10,7 @@ namespace fluXis.Skinning.Default.Stage;
 public partial class DefaultStageBorderLeft : ColorableSkinDrawable
 {
     public DefaultStageBorderLeft(SkinJson skinJson)
-        : base(skinJson, 1)
+        : base(skinJson, MapColor.Primary)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
@@ -10,7 +10,7 @@ namespace fluXis.Skinning.Default.Stage;
 public partial class DefaultStageBorderRight : ColorableSkinDrawable
 {
     public DefaultStageBorderRight(SkinJson skinJson)
-        : base(skinJson)
+        : base(skinJson, 2)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
@@ -40,6 +40,10 @@ public partial class DefaultStageBorderRight : ColorableSkinDrawable
     }
 
     public override void SetColor(Colour4 color) => border.Colour = color;
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => border.FadeColour(color, duration, easing);
+    
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            border.FadeColour(color, duration, easing);
+    }
 }

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
@@ -9,8 +9,10 @@ namespace fluXis.Skinning.Default.Stage;
 
 public partial class DefaultStageBorderRight : ColorableSkinDrawable
 {
+    private Box border;
+
     public DefaultStageBorderRight(SkinJson skinJson)
-        : base(skinJson, MapColor.Secondary)
+        : base(skinJson, MapColor.Primary)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;
@@ -27,7 +29,7 @@ public partial class DefaultStageBorderRight : ColorableSkinDrawable
                 Width = DefaultSkin.BORDER_BASE,
                 Colour = Theme.Background3
             },
-            new Box
+            border = new Box
             {
                 RelativeSizeAxes = Axes.Y,
                 Width = DefaultSkin.BORDER_COLOR,
@@ -36,4 +38,8 @@ public partial class DefaultStageBorderRight : ColorableSkinDrawable
             }
         };
     }
+
+    public override void SetColor(Colour4 color) => border.Colour = color;
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => border.FadeColour(color, duration, easing);
 }

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
@@ -10,7 +10,7 @@ namespace fluXis.Skinning.Default.Stage;
 public partial class DefaultStageBorderRight : ColorableSkinDrawable
 {
     public DefaultStageBorderRight(SkinJson skinJson)
-        : base(skinJson, 2)
+        : base(skinJson, MapColor.Secondary)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;

--- a/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
+++ b/fluXis/Skinning/Default/Stage/DefaultStageBorderRight.cs
@@ -12,7 +12,7 @@ public partial class DefaultStageBorderRight : ColorableSkinDrawable
     private Box border;
 
     public DefaultStageBorderRight(SkinJson skinJson)
-        : base(skinJson, MapColor.Primary)
+        : base(skinJson, MapColor.Secondary)
     {
         AutoSizeAxes = Axes.X;
         RelativeSizeAxes = Axes.Y;
@@ -40,10 +40,4 @@ public partial class DefaultStageBorderRight : ColorableSkinDrawable
     }
 
     public override void SetColor(Colour4 color) => border.Colour = color;
-    
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            border.FadeColour(color, duration, easing);
-    }
 }

--- a/fluXis/Skinning/DefaultCircle/DefaultCircleSkin.cs
+++ b/fluXis/Skinning/DefaultCircle/DefaultCircleSkin.cs
@@ -1,4 +1,5 @@
-﻿using fluXis.Skinning.Default;
+﻿using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Default;
 using fluXis.Skinning.Default.Stage;
 using fluXis.Skinning.DefaultCircle.HitObject;
 using fluXis.Skinning.DefaultCircle.Lighting;
@@ -25,21 +26,24 @@ public class DefaultCircleSkin : DefaultSkin
 
     public override Drawable GetHitObject(int lane, int keyCount)
     {
-        var piece = new DefaultCircleHitObjectPiece(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var piece = new DefaultCircleHitObjectPiece(SkinJson, index);
         piece.UpdateColor(lane, keyCount);
         return piece;
     }
 
     public override Drawable GetLongNoteBody(int lane, int keyCount)
     {
-        var body = new DefaultCircleHitObjectBody(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var body = new DefaultCircleHitObjectBody(SkinJson, index);
         body.UpdateColor(lane, keyCount);
         return body;
     }
 
     public override Drawable GetLongNoteEnd(int lane, int keyCount)
     {
-        var end = new DefaultCircleHitObjectEnd(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var end = new DefaultCircleHitObjectEnd(SkinJson, index);
         end.UpdateColor(lane, keyCount);
         return end;
     }
@@ -63,7 +67,8 @@ public class DefaultCircleSkin : DefaultSkin
 
     public override Drawable GetReceptor(int lane, int keyCount, bool down)
     {
-        var receptor = down ? new DefaultCircleReceptorDown(SkinJson) : new DefaultCircleReceptorUp(SkinJson);
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var receptor = down ? new DefaultCircleReceptorDown(SkinJson, index) : new DefaultCircleReceptorUp(SkinJson, index);
         receptor.UpdateColor(lane, keyCount);
         return receptor;
     }

--- a/fluXis/Skinning/DefaultCircle/DefaultCircleSkin.cs
+++ b/fluXis/Skinning/DefaultCircle/DefaultCircleSkin.cs
@@ -27,7 +27,7 @@ public class DefaultCircleSkin : DefaultSkin
     public override Drawable GetHitObject(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var piece = new DefaultCircleHitObjectPiece(SkinJson, index);
+        var piece = new DefaultCircleHitObjectPiece(SkinJson, (MapColor)index);
         piece.UpdateColor(lane, keyCount);
         return piece;
     }
@@ -35,7 +35,7 @@ public class DefaultCircleSkin : DefaultSkin
     public override Drawable GetLongNoteBody(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var body = new DefaultCircleHitObjectBody(SkinJson, index);
+        var body = new DefaultCircleHitObjectBody(SkinJson, (MapColor)index);
         body.UpdateColor(lane, keyCount);
         return body;
     }
@@ -43,7 +43,7 @@ public class DefaultCircleSkin : DefaultSkin
     public override Drawable GetLongNoteEnd(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var end = new DefaultCircleHitObjectEnd(SkinJson, index);
+        var end = new DefaultCircleHitObjectEnd(SkinJson, (MapColor)index);
         end.UpdateColor(lane, keyCount);
         return end;
     }
@@ -68,7 +68,7 @@ public class DefaultCircleSkin : DefaultSkin
     public override Drawable GetReceptor(int lane, int keyCount, bool down)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);
-        var receptor = down ? new DefaultCircleReceptorDown(SkinJson, index) : new DefaultCircleReceptorUp(SkinJson, index);
+        var receptor = down ? new DefaultCircleReceptorDown(SkinJson, (MapColor)index) : new DefaultCircleReceptorUp(SkinJson, (MapColor)index);
         receptor.UpdateColor(lane, keyCount);
         return receptor;
     }

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectBody.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectBody.cs
@@ -7,8 +7,8 @@ namespace fluXis.Skinning.DefaultCircle.HitObject;
 
 public partial class DefaultCircleHitObjectBody : DefaultHitObjectBody
 {
-    public DefaultCircleHitObjectBody(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultCircleHitObjectBody(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         Width = DefaultCircleSkin.SCALE - 0.01f;
         Masking = true;

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectBody.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectBody.cs
@@ -1,4 +1,5 @@
-﻿using fluXis.Skinning.Default.HitObject;
+﻿using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Default.HitObject;
 using fluXis.Skinning.Json;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -7,7 +8,7 @@ namespace fluXis.Skinning.DefaultCircle.HitObject;
 
 public partial class DefaultCircleHitObjectBody : DefaultHitObjectBody
 {
-    public DefaultCircleHitObjectBody(SkinJson skinJson, int index)
+    public DefaultCircleHitObjectBody(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         Width = DefaultCircleSkin.SCALE - 0.01f;

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectEnd.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectEnd.cs
@@ -1,4 +1,5 @@
-﻿using fluXis.Skinning.Json;
+﻿using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Json;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 
@@ -6,7 +7,7 @@ namespace fluXis.Skinning.DefaultCircle.HitObject;
 
 public partial class DefaultCircleHitObjectEnd : DefaultCircleHitObjectPiece
 {
-    public DefaultCircleHitObjectEnd(SkinJson skinJson, int index)
+    public DefaultCircleHitObjectEnd(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         Circle.BorderColour = ColourInfo.GradientVertical(Colour4.White.Darken(0.2f), Colour4.White);

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectEnd.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectEnd.cs
@@ -6,8 +6,8 @@ namespace fluXis.Skinning.DefaultCircle.HitObject;
 
 public partial class DefaultCircleHitObjectEnd : DefaultCircleHitObjectPiece
 {
-    public DefaultCircleHitObjectEnd(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultCircleHitObjectEnd(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         Circle.BorderColour = ColourInfo.GradientVertical(Colour4.White.Darken(0.2f), Colour4.White);
         Circle.Child.Colour = Colour4.White.Darken(0.2f);

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
@@ -12,8 +12,8 @@ public partial class DefaultCircleHitObjectPiece : ColorableSkinDrawable, ICanHa
 {
     protected Circle Circle { get; }
 
-    public DefaultCircleHitObjectPiece(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultCircleHitObjectPiece(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;
         Anchor = Anchor.BottomCentre;

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
@@ -1,4 +1,5 @@
-﻿using fluXis.Skinning.Bases;
+﻿using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Bases;
 using fluXis.Skinning.Bases.HitObjects;
 using fluXis.Skinning.Json;
 using osu.Framework.Graphics;
@@ -12,7 +13,7 @@ public partial class DefaultCircleHitObjectPiece : ColorableSkinDrawable, ICanHa
 {
     protected Circle Circle { get; }
 
-    public DefaultCircleHitObjectPiece(SkinJson skinJson, int index)
+    public DefaultCircleHitObjectPiece(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
@@ -36,7 +36,10 @@ public partial class DefaultCircleHitObjectPiece : ColorableSkinDrawable, ICanHa
         Height = DrawWidth;
     }
 
-    protected override void SetColor(Colour4 color) => Circle.Colour = color;
+    public override void SetColor(Colour4 color) => Circle.Colour = color;
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => Circle.FadeColour(color, duration, easing);
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
@@ -39,12 +39,6 @@ public partial class DefaultCircleHitObjectPiece : ColorableSkinDrawable, ICanHa
 
     public override void SetColor(Colour4 color) => Circle.Colour = color;
 
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-            Circle.FadeColour(color, duration, easing);
-    }
-
     public void ApplySnapColor(int start, int end)
     {
         UseCustomColor = true;

--- a/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
+++ b/fluXis/Skinning/DefaultCircle/HitObject/DefaultCircleHitObjectPiece.cs
@@ -39,8 +39,11 @@ public partial class DefaultCircleHitObjectPiece : ColorableSkinDrawable, ICanHa
 
     public override void SetColor(Colour4 color) => Circle.Colour = color;
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => Circle.FadeColour(color, duration, easing);
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
+    {
+        using (BeginAbsoluteSequence(startTime))
+            Circle.FadeColour(color, duration, easing);
+    }
 
     public void ApplySnapColor(int start, int end)
     {

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
@@ -12,7 +12,10 @@ public partial class DefaultCircleReceptorDown : DefaultCircleReceptorUp
         Circle.BorderThickness = 16;
     }
 
-    protected override void SetColor(Colour4 color) => Colour = color;
+    public override void SetColor(Colour4 color) => Colour = color;
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => this.FadeColour(color, duration, easing);
 
     public override void Show() => this.FadeInFromZero();
 }

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
@@ -1,11 +1,12 @@
-﻿using fluXis.Skinning.Json;
+﻿using fluXis.Graphics.UserInterface.Color;
+using fluXis.Skinning.Json;
 using osu.Framework.Graphics;
 
 namespace fluXis.Skinning.DefaultCircle.Receptor;
 
 public partial class DefaultCircleReceptorDown : DefaultCircleReceptorUp
 {
-    public DefaultCircleReceptorDown(SkinJson skinJson, int index)
+    public DefaultCircleReceptorDown(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         Alpha = 0;

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
@@ -13,10 +13,5 @@ public partial class DefaultCircleReceptorDown : DefaultCircleReceptorUp
         Circle.BorderThickness = 16;
     }
 
-    public override void SetColor(Colour4 color) => Colour = color;
-
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => this.FadeColour(color, duration, easing);
-
     public override void Show() => this.FadeInFromZero();
 }

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorDown.cs
@@ -5,8 +5,8 @@ namespace fluXis.Skinning.DefaultCircle.Receptor;
 
 public partial class DefaultCircleReceptorDown : DefaultCircleReceptorUp
 {
-    public DefaultCircleReceptorDown(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultCircleReceptorDown(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         Alpha = 0;
         Circle.BorderThickness = 16;

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
@@ -18,7 +18,7 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
     private IBeatSyncProvider beatSync { get; set; }
 
     protected OutlinedCircle Circle { get; }
-    private Colour4 color { get; set; }
+    private Colour4 colour { get; set; }
 
     public DefaultCircleReceptorUp(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
@@ -43,14 +43,18 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
 
     public override void SetColor(Colour4 color)
     {
-        this.color = color;
+        colour = color;
         Circle.Colour = color.Lighten(0.4f);
     }
 
-    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
     {
-        this.FadeColour(color, duration, easing);
-        Circle.FadeColour(color.Lighten(0.4f), duration, easing);
+        using (BeginAbsoluteSequence(startTime))
+        {
+            this.FadeColour(color, duration, easing);
+            this.TransformTo(nameof(colour), color, duration, easing);
+            Circle.FadeColour(color.Lighten(0.4f), duration, easing);
+        }
     }
 
     protected override void Update()
@@ -65,7 +69,7 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
         var duration = beatSync?.BeatTime ?? 200;
         this.FadeInFromZero().FadeTo(.25f, duration / 2);
 
-        Circle.BorderTo(16).FadeColour(color)
-              .BorderTo(8, duration, Easing.OutQuint).FadeColour(color.Lighten(.4f), duration / 2);
+        Circle.BorderTo(16).FadeColour(colour)
+              .BorderTo(8, duration, Easing.OutQuint).FadeColour(colour.Lighten(.4f), duration / 2);
     }
 }

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
@@ -47,16 +47,6 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
         Circle.Colour = color.Lighten(0.4f);
     }
 
-    public override void FadeColor(Colour4 color, double startTime, double duration = 0, Easing easing = Easing.None)
-    {
-        using (BeginAbsoluteSequence(startTime))
-        {
-            this.FadeColour(color, duration, easing);
-            this.TransformTo(nameof(colour), color, duration, easing);
-            Circle.FadeColour(color.Lighten(0.4f), duration, easing);
-        }
-    }
-
     protected override void Update()
     {
         base.Update();

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
@@ -1,5 +1,6 @@
 ﻿using fluXis.Audio;
 using fluXis.Graphics.Sprites.Outline;
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Skinning.Bases;
 using fluXis.Skinning.Json;
 using fluXis.Utils.Extensions;
@@ -19,7 +20,7 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
     protected OutlinedCircle Circle { get; }
     private Colour4 color { get; set; }
 
-    public DefaultCircleReceptorUp(SkinJson skinJson, int index)
+    public DefaultCircleReceptorUp(SkinJson skinJson, MapColor index)
         : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
@@ -40,10 +40,16 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
         };
     }
 
-    protected override void SetColor(Colour4 color)
+    public override void SetColor(Colour4 color)
     {
         this.color = color;
         Circle.Colour = color.Lighten(0.4f);
+    }
+
+    public override void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+    {
+        this.FadeColour(color, duration, easing);
+        Circle.FadeColour(color.Lighten(0.4f), duration, easing);
     }
 
     protected override void Update()

--- a/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
+++ b/fluXis/Skinning/DefaultCircle/Receptor/DefaultCircleReceptorUp.cs
@@ -19,8 +19,8 @@ public partial class DefaultCircleReceptorUp : ColorableSkinDrawable
     protected OutlinedCircle Circle { get; }
     private Colour4 color { get; set; }
 
-    public DefaultCircleReceptorUp(SkinJson skinJson)
-        : base(skinJson)
+    public DefaultCircleReceptorUp(SkinJson skinJson, int index)
+        : base(skinJson, index)
     {
         RelativeSizeAxes = Axes.X;
         Anchor = Anchor.BottomCentre;

--- a/fluXis/Skinning/Json/SkinKeymode.cs
+++ b/fluXis/Skinning/Json/SkinKeymode.cs
@@ -24,6 +24,13 @@ public class SkinKeymode
     [JsonProperty("tint_lns")]
     public bool TintLongNotes { get; set; } = true;
 
+    /// <summary>
+    /// tints the receptors.
+    /// only applies when <see cref="TintReceptors"/> is true.
+    /// </summary>
+    [JsonProperty("tint_receptors")]
+    public bool TintReceptors { get; set; } = false;
+
     [JsonProperty("colors")]
     public List<string> Colors { get; set; } = new();
 

--- a/fluXis/Skinning/SkinnableSprite.cs
+++ b/fluXis/Skinning/SkinnableSprite.cs
@@ -7,12 +7,10 @@ namespace fluXis.Skinning;
 public partial class SkinnableSprite : Sprite
 {
     public bool SkipResizing { get; set; }
-    public int Index { get; set; }
 
-    public SkinnableSprite(Texture texture = null, int index = 0)
+    public SkinnableSprite(Texture texture = null)
     {
         Texture = texture;
-        Index = index;
     }
 
     protected override void Update()
@@ -34,10 +32,4 @@ public partial class SkinnableSprite : Sprite
             }
         }
     }
-
-    public void SetColor(Colour4 color)
-        => Colour = color;
-
-    public void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
-        => this.FadeColour(color, duration, easing);
 }

--- a/fluXis/Skinning/SkinnableSprite.cs
+++ b/fluXis/Skinning/SkinnableSprite.cs
@@ -7,10 +7,12 @@ namespace fluXis.Skinning;
 public partial class SkinnableSprite : Sprite
 {
     public bool SkipResizing { get; set; }
+    public int Index { get; set; }
 
-    public SkinnableSprite(Texture texture = null)
+    public SkinnableSprite(Texture texture = null, int index = 0)
     {
         Texture = texture;
+        Index = index;
     }
 
     protected override void Update()
@@ -32,4 +34,10 @@ public partial class SkinnableSprite : Sprite
             }
         }
     }
+
+    public void SetColor(Colour4 color)
+        => Colour = color;
+
+    public void FadeColor(Colour4 color, double duration = 0, Easing easing = Easing.None)
+        => this.FadeColour(color, duration, easing);
 }

--- a/fluXis/Utils/MapUtils.cs
+++ b/fluXis/Utils/MapUtils.cs
@@ -183,6 +183,9 @@ public static class MapUtils
         if (events.FlashEvents.Count > 0)
             effects |= MapEffectType.Flash;
 
+        if (events.ColorFadeEvents.Count > 0)
+            effects |= MapEffectType.ColorFade;
+
         if (events.PulseEvents.Count > 0)
             effects |= MapEffectType.Pulse;
 


### PR DESCRIPTION
## Changes
- (Slightly) Reworked how colors are set for colorable skin elements
- Receptors can now be tinted
- New ``tint_receptors`` json field for keymode
- Setting Map colors from setup tab now updates colors properly when moving to design tab
- New ``Color Fade`` Event
- New ColorManager per playfield for managing colors