### PR TITLE
Prevent Last Leaderboard Entry From Clipping With Footer

### DIFF
--- a/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListTab.cs
+++ b/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListTab.cs
@@ -105,7 +105,8 @@ public partial class ScoreListTab : SelectInfoTab
             list = new FluXisScrollContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                ScrollbarVisible = false
+                ScrollbarVisible = false,
+                Padding = new MarginPadding { Bottom = 52 } // to prevent clipping with footer
             },
             loading = new LoadingIcon
             {


### PR DESCRIPTION
Before:

<img width="1035" height="727" alt="{3071E719-EBE3-4BA2-8F93-4814E1C2EDA6}2" src="https://github.com/user-attachments/assets/5375efed-678e-45d4-bd9b-feffe3cdc783" />

After:

![202510080919-ezgif com-optimize](https://github.com/user-attachments/assets/37daeb9e-157e-4a0b-a020-d6b3b5e656e6)




And yes we did need that many arrows.