### PR TITLE
Add Overlapping Notes Verify Check

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Verify/Checks/HitObjects/OverlappingCheck.cs
+++ b/fluXis/Screens/Edit/Tabs/Verify/Checks/HitObjects/OverlappingCheck.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using fluXis.Map.Structures;
+using osu.Framework.Utils;
+
+namespace fluXis.Screens.Edit.Tabs.Verify.Checks.HitObjects;
+
+public class OverlappingCheck : IVerifyCheck
+{
+    public IEnumerable<VerifyIssue> Check(IVerifyContext ctx)
+    {
+        var hits = ctx.MapInfo.HitObjects;
+        if (hits.Count == 0) yield break;
+
+        foreach (var lane in hits.GroupBy(h => h.Lane))
+        {
+            var hitObjects = lane.ToList();
+            if (hitObjects.Count == 0) continue;
+
+            HitObject currentLn = null;
+
+            foreach (var (prev, current) in hitObjects.Zip(hitObjects.Skip(1)))
+            {
+                if (prev.HoldTime > 0 && (currentLn == null || prev.EndTime > currentLn.EndTime))
+                    currentLn = prev;
+
+                bool overlappingTime = Precision.AlmostEquals(current.Time, prev.Time);
+                bool overlappingEndTime = currentLn != null && Precision.AlmostEquals(current.Time, currentLn.EndTime);
+                bool insideLn = currentLn != null && current.Type != 1 // except for tick notes inside LNs
+                                                  && current.Time > currentLn.Time && current.Time < currentLn.EndTime;
+
+                if (overlappingTime || insideLn || overlappingEndTime)
+                {
+                    yield return new VerifyIssue(
+                        VerifyIssueSeverity.Warning,
+                        VerifyIssueCategory.HitObjects,
+                        current.Time,
+                        $"Overlapping notes at lane {lane.Key}."
+                    );
+                }
+
+                if (currentLn != null && current.Time >= currentLn.EndTime)
+                    currentLn = null;
+            }
+        }
+    }
+}

--- a/fluXis/Screens/Edit/Tabs/Verify/VerifyIssueEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Verify/VerifyIssueEntry.cs
@@ -1,20 +1,33 @@
 ﻿using System.Linq;
+using fluXis.Audio;
 using fluXis.Graphics.Sprites.Text;
 using fluXis.Graphics.UserInterface.Color;
 using fluXis.Graphics.UserInterface.Interaction;
+using fluXis.Overlay.Notifications;
 using fluXis.Utils;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
+using osu.Framework.Platform;
 
 namespace fluXis.Screens.Edit.Tabs.Verify;
 
 public partial class VerifyIssueEntry : CompositeDrawable
 {
+    [Resolved]
+    private NotificationManager notifications { get; set; }
+
+    [Resolved]
+    private Clipboard clipboard { get; set; }
+
+    [Resolved]
+    private UISamples samples { get; set; }
+
     private VerifyIssue issue { get; }
 
     private HoverLayer hover;
+    private FlashLayer flash;
 
     public VerifyIssueEntry(VerifyIssue issue)
     {
@@ -40,6 +53,7 @@ public partial class VerifyIssueEntry : CompositeDrawable
         InternalChildren = new Drawable[]
         {
             hover = new HoverLayer { Colour = color },
+            flash = new FlashLayer { Colour = color.Lighten(.5f).Opacity(.5f) },
             new Container
             {
                 RelativeSizeAxes = Axes.Both,
@@ -96,8 +110,22 @@ public partial class VerifyIssueEntry : CompositeDrawable
         };
     }
 
+    protected override bool OnClick(ClickEvent e)
+    {
+        if (issue.Time == null) return false;
+
+        clipboard.SetText(((int)issue.Time).ToString());
+        notifications.SendSmallText("Copied issue time to clipboard.");
+
+        samples.Click();
+        flash.Show();
+
+        return true;
+    }
+
     protected override bool OnHover(HoverEvent e)
     {
+        if (issue.Time != null) samples.Hover();
         hover.Show();
         return true;
     }


### PR DESCRIPTION
## Changes
- add check for overlapping notes which checks for notes if:
  * has same start time
  * a note is at an LN endtime
  * a note is inside an LN (with the exception of tick notes)
- ability to copy the time for issues by clicking on them (if its issue has time)

Resolves #70
Resolves #226