### PR TITLE
[PERFORMANCE] Implement Dynamic Storyboard Building

### DIFF
--- a/fluXis.Import.osu/Storyboards/OsuStoryboardParser.cs
+++ b/fluXis.Import.osu/Storyboards/OsuStoryboardParser.cs
@@ -68,7 +68,7 @@ public class OsuStoryboardParser
             {
                 if (initialValues.Add(animation.Type))
                 {
-                    toAdd.Add(new StoryboardAnimation
+                    toAdd.Add(new StoryboardAnimation(element)
                     {
                         Type = animation.Type,
                         ValueStart = animation.ValueStart,
@@ -208,7 +208,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.Fade,
                                     StartTime = startTime,
@@ -229,7 +229,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.Scale,
                                     StartTime = startTime,
@@ -252,7 +252,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.ScaleVector,
                                     StartTime = startTime,
@@ -276,7 +276,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.Rotate,
                                     StartTime = startTime,
@@ -299,7 +299,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.MoveX,
                                     StartTime = startTime,
@@ -308,7 +308,7 @@ public class OsuStoryboardParser
                                     ValueStart = startX.ToStringInvariant(),
                                     ValueEnd = endX.ToStringInvariant()
                                 },
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.MoveY,
                                     StartTime = startTime,
@@ -329,7 +329,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.MoveX,
                                     StartTime = startTime,
@@ -350,7 +350,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.MoveY,
                                     StartTime = startTime,
@@ -378,7 +378,7 @@ public class OsuStoryboardParser
 
                             buffer = new[]
                             {
-                                new StoryboardAnimation
+                                new StoryboardAnimation(currentElement)
                                 {
                                     Type = StoryboardAnimationType.Color,
                                     StartTime = startTime,

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Animations/StoryboardAnimationRow.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Animations/StoryboardAnimationRow.cs
@@ -91,7 +91,7 @@ public partial class StoryboardAnimationRow : GridContainer
 
     private void addNew()
     {
-        var animation = new StoryboardAnimation
+        var animation = new StoryboardAnimation(Item)
         {
             StartTime = clock.CurrentTime - Item.StartTime,
             ValueStart = getDefault(type),
@@ -114,7 +114,12 @@ public partial class StoryboardAnimationRow : GridContainer
     }
 
     private StoryboardAnimationEntry createEntry(StoryboardAnimation anim)
-        => new(anim, this, color) { RequestRemove = remove };
+    {
+        // Restore the parent reference lost during json deserialization (because of [JsonIgnore] on ParentElement).
+        anim.ParentElement ??= Item;
+
+        return new StoryboardAnimationEntry(anim, this, color) { RequestRemove = remove };
+    }
 
     private static string getDefault(StoryboardAnimationType type)
     {

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/StoryboardTab.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/StoryboardTab.cs
@@ -13,7 +13,6 @@ using fluXis.Screens.Edit.Tabs.Storyboarding.Timeline;
 using fluXis.Storyboards;
 using fluXis.Storyboards.Drawables;
 using fluXis.Utils;
-using Midori.Utils;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/StoryboardTab.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/StoryboardTab.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using fluXis.Graphics.Containers;
 using fluXis.Graphics.Sprites;
 using fluXis.Graphics.Sprites.Icons;
 using fluXis.Graphics.UserInterface.Color;
+using fluXis.Map;
 using fluXis.Map.Drawables;
 using fluXis.Screens.Edit.Tabs.Storyboarding.Animations;
 using fluXis.Screens.Edit.Tabs.Storyboarding.Settings;
@@ -44,6 +46,16 @@ public partial class StoryboardTab : EditorTab
     private AspectRatioContainer aspect;
     private IdleTracker idleTracker;
     private Container loading;
+    private Box backgroundDim;
+
+    private Storyboard storyboard => map.Storyboard;
+    private DrawableDynamicStoryboard dynamicStoryboard;
+    private DrawableDynamicStoryboardLayer[] layers;
+
+    private readonly List<StoryboardElement> scriptsToBeRebuilt = new();
+    private readonly List<StoryboardElement> scriptsToBeRemoved = new();
+
+    private bool loadingFromRanges;
 
     [BackgroundDependencyLoader]
     private void load()
@@ -55,8 +67,34 @@ public partial class StoryboardTab : EditorTab
         dependencies.CacheAs<ITimePositionProvider>(timeline);
         dependencies.CacheAs(timeline.Blueprints);
 
+        LoadComponent(dynamicStoryboard = new DrawableDynamicStoryboard
+        (
+            new Bindable<MapInfo>(map.MapInfo),
+            new Bindable<Storyboard>(storyboard),
+            editor.MapSetPath
+        ));
+
+        layers = Enum.GetValues<StoryboardLayer>()
+                     .Select(x => new DrawableDynamicStoryboardLayer(clock, dynamicStoryboard, x))
+                     .ToArray();
+
+        aspect = new AspectRatioContainer(new BindableBool(true))
+        {
+            CornerRadius = 12,
+            Masking = true
+        };
+        aspect.Add(new MapBackground(map.RealmMap) { RelativeSizeAxes = Axes.Both });
+        aspect.Add(backgroundDim = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            Colour = Colour4.Black,
+            Alpha = editor.BindableBackgroundDim.Value
+        });
+        aspect.AddRange(layers);
+
         InternalChildren = new Drawable[]
         {
+            dynamicStoryboard,
             idleTracker = new IdleTracker(400, rebuildPreview),
             new GridContainer
             {
@@ -98,11 +136,7 @@ public partial class StoryboardTab : EditorTab
                                             {
                                                 RelativeSizeAxes = Axes.Both,
                                                 Padding = new MarginPadding(12),
-                                                Child = aspect = new AspectRatioContainer(new BindableBool(true))
-                                                {
-                                                    CornerRadius = 12,
-                                                    Masking = true
-                                                }
+                                                Child = aspect
                                             },
                                             loading = new Container
                                             {
@@ -138,59 +172,142 @@ public partial class StoryboardTab : EditorTab
                 }
             }
         };
-
-        rebuildPreview();
     }
 
     protected override void LoadComplete()
     {
         base.LoadComplete();
 
-        map.Storyboard.ElementAdded += queueRebuild;
-        map.Storyboard.ElementRemoved += queueRebuild;
-        map.Storyboard.ElementUpdated += queueRebuild;
-        map.RegisterAddListener<StoryboardAnimation>(queueRebuild);
-        map.RegisterUpdateListener<StoryboardAnimation>(queueRebuild);
-        map.RegisterRemoveListener<StoryboardAnimation>(queueRebuild);
+        map.Storyboard.ElementAdded += onElementAdded;
+        map.Storyboard.ElementRemoved += onElementRemoved;
+        map.Storyboard.ElementUpdated += onElementUpdated;
+
+        map.RegisterAddListener<StoryboardAnimation>(onAnimationUpdated);
+        map.RegisterUpdateListener<StoryboardAnimation>(onAnimationUpdated);
+        map.RegisterRemoveListener<StoryboardAnimation>(onAnimationUpdated);
 
         map.ScriptChanged += queueRebuild;
     }
 
-    private void queueRebuild(StoryboardElement _) => queueRebuild();
-    private void queueRebuild(StoryboardAnimation _) => queueRebuild();
-    private void queueRebuild(string _) => queueRebuild();
-
-    private void queueRebuild()
+    protected override void Update()
     {
+        base.Update();
+        updateLoadingFromRanges();
+    }
+
+    /// <summary>
+    /// Not to be confused with actual loading; This only updates the loading icon's visibility
+    /// </summary>
+    private void updateLoadingFromRanges()
+    {
+        float currentTime = (float)clock.CurrentTime;
+        var ranges = dynamicStoryboard.LoadedRanges;
+
+        var active = ranges.Where(r => currentTime >= r.Item1 && currentTime <= r.Item2).ToList();
+
+        bool shouldShow = active.Count > 0 && active.Any(r => !r.Item3);
+
+        if (shouldShow == loadingFromRanges)
+            return;
+
+        loadingFromRanges = shouldShow;
+
+        if (shouldShow)
+            loading.FadeIn(300);
+        else
+            loading.FadeOut(300);
+    }
+
+    #region Event Handling
+
+    private void onElementAdded(StoryboardElement e)
+    {
+        if (e.Type == StoryboardElementType.Script)
+            queueRebuild(e);
+        else
+        {
+            // TODO: maybe don't iterate over all layers in the future?
+            foreach (var layer in layers)
+                layer.AddStaticElement(e);
+        }
+
+        storyboard.Sort();
+    }
+
+    private void onElementRemoved(StoryboardElement e)
+    {
+        if (e.Type == StoryboardElementType.Script)
+        {
+            scriptsToBeRemoved.Add(e);
+            loading.FadeIn(300);
+            idleTracker.Reset();
+        }
+        else
+        {
+            // TODO: maybe don't iterate over all layers in the future?
+            foreach (var layer in layers)
+                layer.RemoveStaticElement(e);
+        }
+
+        storyboard.Sort();
+    }
+
+    private void onElementUpdated(StoryboardElement e)
+    {
+        if (e.Type == StoryboardElementType.Script)
+            queueRebuild(e);
+        else
+        {
+            // TODO: maybe don't iterate over all layers in the future?
+            foreach (var layer in layers)
+                layer.UpdateStaticElement(e);
+        }
+
+        storyboard.Sort();
+    }
+
+    private void onAnimationUpdated(StoryboardAnimation a) => onElementUpdated(a.ParentElement);
+
+    #endregion
+
+    #region Building
+
+    private void queueRebuild(StoryboardElement e)
+    {
+        scriptsToBeRebuilt.Clear();
+        scriptsToBeRebuilt.Add(e);
+
+        loading.FadeIn(300);
+        idleTracker.Reset();
+    }
+
+    private void queueRebuild(string s)
+    {
+        scriptsToBeRebuilt.Clear();
+        scriptsToBeRebuilt.AddRange(storyboard.GetScriptElements(s));
+
         loading.FadeIn(300);
         idleTracker.Reset();
     }
 
     private void rebuildPreview()
     {
-        aspect.Clear();
+        backgroundDim.Alpha = editor.BindableBackgroundDim.Value;
 
-        var copy = map.Storyboard.JsonCopy();
+        if (scriptsToBeRemoved.Count > 0)
+            dynamicStoryboard.RemoveElements(scriptsToBeRemoved);
 
-        var draw = new DrawableStoryboard(map.MapInfo, copy, editor.MapSetPath);
-        LoadComponent(draw);
+        if (scriptsToBeRebuilt.Count > 0)
+            dynamicStoryboard.RebuildElements(scriptsToBeRebuilt);
 
-        aspect.AddRange(new Drawable[]
-        {
-            new MapBackground(map.RealmMap)
-            {
-                RelativeSizeAxes = Axes.Both
-            },
-            new Box
-            {
-                RelativeSizeAxes = Axes.Both,
-                Colour = Colour4.Black,
-                Alpha = editor.BindableBackgroundDim.Value
-            }
-        });
-        aspect.AddRange(Enum.GetValues<StoryboardLayer>().Select(x => new DrawableStoryboardLayer(clock, draw, x)).ToArray());
-        ScheduleAfterChildren(() => loading.FadeOut(300));
+        scriptsToBeRemoved.Clear();
+        scriptsToBeRebuilt.Clear();
+
+        if (!loadingFromRanges)
+            ScheduleAfterChildren(() => loading.FadeOut(300));
     }
+
+    #endregion
 
     protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
@@ -248,5 +365,22 @@ public partial class StoryboardTab : EditorTab
             clock.SeekBackward(amount);
         else
             clock.SeekForward(amount);
+    }
+
+    protected override void Dispose(bool isDisposing)
+    {
+        base.Dispose(isDisposing);
+
+        if (map == null) return;
+
+        map.Storyboard.ElementAdded -= onElementAdded;
+        map.Storyboard.ElementRemoved -= onElementRemoved;
+        map.Storyboard.ElementUpdated -= onElementUpdated;
+
+        map.DeregisterAddListener<StoryboardAnimation>(onAnimationUpdated);
+        map.DeregisterUpdateListener<StoryboardAnimation>(onAnimationUpdated);
+        map.DeregisterRemoveListener<StoryboardAnimation>(onAnimationUpdated);
+
+        map.ScriptChanged -= queueRebuild;
     }
 }

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/StoryboardTab.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/StoryboardTab.cs
@@ -201,11 +201,17 @@ public partial class StoryboardTab : EditorTab
     private void updateLoadingFromRanges()
     {
         float currentTime = (float)clock.CurrentTime;
-        var ranges = dynamicStoryboard.LoadedRanges;
 
-        var active = ranges.Where(r => currentTime >= r.Item1 && currentTime <= r.Item2).ToList();
+        bool shouldShow = false;
 
-        bool shouldShow = active.Count > 0 && active.Any(r => !r.Item3);
+        foreach (var r in dynamicStoryboard.LoadedRanges)
+        {
+            if (currentTime >= r.Item1 && currentTime <= r.Item2 && !r.Item3)
+            {
+                shouldShow = true;
+                break;
+            }
+        }
 
         if (shouldShow == loadingFromRanges)
             return;

--- a/fluXis/Scripting/Models/Storyboarding/LuaStoryboardAnimation.cs
+++ b/fluXis/Scripting/Models/Storyboarding/LuaStoryboardAnimation.cs
@@ -6,6 +6,11 @@ namespace fluXis.Scripting.Models.Storyboarding;
 
 public class LuaStoryboardAnimation : ILuaModel
 {
+    public LuaStoryboardAnimation(LuaStoryboardElement parentElement)
+    {
+        ParentElement = parentElement;
+    }
+
     [LuaMember(Name = "time")]
     public double StartTime { get; set; }
 
@@ -24,7 +29,13 @@ public class LuaStoryboardAnimation : ILuaModel
     [LuaMember(Name = "end")]
     public string End { get; set; }
 
-    public StoryboardAnimation Build() => new()
+    [LuaHide]
+    public LuaStoryboardElement ParentElement;
+
+    // TODO:
+    // this is probably a bad idea for the future but also I don't think that building parent element for every animation is the right approach
+    // It will be kept as null for now since we don't access lua animations' parent elements
+    public StoryboardAnimation Build() => new(null)
     {
         StartTime = StartTime,
         Duration = Duration,

--- a/fluXis/Scripting/Models/Storyboarding/LuaStoryboardElement.cs
+++ b/fluXis/Scripting/Models/Storyboarding/LuaStoryboardElement.cs
@@ -71,7 +71,7 @@ public class LuaStoryboardElement : ILuaModel
     /// <param name="ease">the easing function used for this animation</param>
     [LuaMember(Name = "animate")]
     public void AddAnimation([LuaCustomType(typeof(StoryboardAnimationType))] string type, float time, float len, string startVal, string endVal, [LuaCustomType(typeof(Easing))] string ease) =>
-        Animations.Add(new LuaStoryboardAnimation
+        Animations.Add(new LuaStoryboardAnimation(this)
         {
             StartTime = time,
             Duration = len,

--- a/fluXis/Scripting/Runners/StoryboardScriptRunner.cs
+++ b/fluXis/Scripting/Runners/StoryboardScriptRunner.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using fluXis.Audio.FFT;
+using fluXis.Graphics;
 using fluXis.Map;
 using fluXis.Map.Structures;
 using fluXis.Scripting.Attributes;
@@ -15,17 +17,30 @@ using osu.Framework.Logging;
 namespace fluXis.Scripting.Runners;
 
 [LuaDefinition("storyboard", Hide = true)]
-public class StoryboardScriptRunner : ScriptRunner
+public class StoryboardScriptRunner : ScriptRunner, IHasLoadedValue
 {
+    private readonly List<StoryboardElement> addTo;
+
     private readonly Storyboard storyboard;
+
+    public bool Loaded { get; private set; }
 
     [LuaGlobal(Name = "screen")]
     public LuaVector2 ScreenResolution { get; }
 
-    public StoryboardScriptRunner(MapInfo map, AudioAnalyzer audioAnalyzer, Storyboard storyboard, LuaSettings settings, ISkin skin)
+    public StoryboardScriptRunner
+    (
+        MapInfo map,
+        AudioAnalyzer audioAnalyzer,
+        Storyboard storyboard,
+        LuaSettings settings,
+        ISkin skin,
+        List<StoryboardElement> addTo = null)
     {
         this.storyboard = storyboard;
         Map = map;
+
+        this.addTo = addTo ?? this.storyboard.Elements;
 
         ScreenResolution = new LuaVector2(storyboard.Resolution);
         AddField("screen", ScreenResolution);
@@ -67,6 +82,7 @@ public class StoryboardScriptRunner : ScriptRunner
 
             var l = LuaStoryboardElement.FromElement(element);
             func.Call(l);
+            Loaded = true;
         }
         catch (Exception ex)
         {
@@ -91,7 +107,7 @@ public class StoryboardScriptRunner : ScriptRunner
             }
         }
 
-        storyboard.Elements.Add(element.Build());
+        addTo.Add(element.Build());
     }
 
     [LuaGlobal(Name = "StoryboardBox")]

--- a/fluXis/Storyboards/Drawables/DrawableDynamicStoryboard.cs
+++ b/fluXis/Storyboards/Drawables/DrawableDynamicStoryboard.cs
@@ -6,7 +6,7 @@ using fluXis.Graphics;
 using fluXis.Map;
 using fluXis.Screens.Edit;
 using fluXis.Scripting.Runners;
-using fluXis.Utils;
+using Midori.Utils;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;

--- a/fluXis/Storyboards/Drawables/DrawableDynamicStoryboard.cs
+++ b/fluXis/Storyboards/Drawables/DrawableDynamicStoryboard.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using fluXis.Graphics;
+using fluXis.Map;
+using fluXis.Screens.Edit;
+using fluXis.Scripting.Runners;
+using fluXis.Utils;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Logging;
+
+namespace fluXis.Storyboards.Drawables;
+
+public partial class DrawableDynamicStoryboard : DrawableStoryboard
+{
+    [Resolved]
+    private EditorClock clock { get; set; }
+
+    /// <summary>
+    /// (time, endtime, isLoaded)
+    /// </summary>
+    public BindableList<(float, float, bool)> LoadedRanges { get; } = new();
+
+    /// <summary>
+    /// ALWAYS use this instead of <see cref="DrawableStoryboard.Storyboard"/> for dynamic loading!
+    /// If you don't you'll encounter desync issues and element duplication.
+    /// </summary>
+    public Bindable<Storyboard> BindableStoryboard { get; }
+
+    public Action<StoryboardLayer, StoryboardElement, IEnumerable<StoryboardElement>> ScriptElementsAdded;
+    public Action<StoryboardLayer, StoryboardElement> ScriptElementsRemoved;
+    public Action<StoryboardLayer> Updated;
+
+    private Dictionary<string, StoryboardScriptRunner> scriptsLookup { get; } = new();
+    private Queue<Func<Task>> loadQueue { get; } = new();
+    private HashSet<ScriptState> pendingStates { get; } = new();
+    private List<ScriptState> scripts { get; } = new();
+
+    public DrawableDynamicStoryboard(Bindable<MapInfo> map, Bindable<Storyboard> storyboard, string assetPath)
+        : base(map.Value, storyboard.Value.JsonCopy(), assetPath)
+    {
+        BindableStoryboard = storyboard;
+    }
+
+    public void RebuildElements(IEnumerable<StoryboardElement> elements)
+    {
+        foreach (var element in elements.Where(e => e.Type == StoryboardElementType.Script))
+        {
+            var state = scripts.FirstOrDefault(s => s.SourceElement == element);
+
+            if (state == null)
+            {
+                state = new ScriptState
+                {
+                    SourceElement = element,
+                    Loaded = false
+                };
+
+                state.OnRebuildStart = () =>
+                {
+                    state.Loaded = false;
+                    syncLoadedRanges();
+                };
+
+                state.OnRebuildFinish = () =>
+                {
+                    state.Loaded = true;
+                    syncLoadedRanges();
+
+                    foreach (var l in state.Elements.Select(e => e.Layer).Distinct())
+                        Updated?.Invoke(l);
+                };
+
+                scripts.Add(state);
+            }
+
+            if (state.Loaded)
+            {
+                foreach (var l in state.Elements.Select(e => e.Layer).Distinct())
+                    ScriptElementsRemoved?.Invoke(l, state.SourceElement);
+            }
+
+            state.Elements.Clear();
+            state.Time = (float)element.StartTime;
+            state.Endtime = (float)element.EndTime;
+
+            var path = element.GetParameter("path", "");
+            var script = LoadScript(path, state.Elements);
+
+            if (script != null)
+            {
+                script.Process(element);
+                state.Script = script;
+            }
+
+            state.Loaded = false;
+            syncLoadedRanges();
+
+            pendingStates.Add(state);
+            loadQueue.Enqueue(() => activateScriptAsync(state));
+        }
+    }
+
+    public void RemoveElements(IEnumerable<StoryboardElement> elements)
+    {
+        foreach (var element in elements.Where(e => e.Type == StoryboardElementType.Script))
+        {
+            var state = scripts.FirstOrDefault(s => s.SourceElement == element);
+            if (state == null) continue;
+
+            if (state.Loaded)
+            {
+                foreach (var l in state.Elements.Select(e => e.Layer).Distinct())
+                    ScriptElementsRemoved?.Invoke(l, state.SourceElement);
+            }
+
+            scripts.Remove(state);
+            pendingStates.Remove(state);
+        }
+
+        syncLoadedRanges();
+    }
+
+    protected override void LoadScripts()
+    {
+        var elements = BindableStoryboard.Value.Elements
+                                         .Where(e => e.Type == StoryboardElementType.Script)
+                                         .ToList();
+
+        foreach (var element in elements)
+        {
+            var path = element.GetParameter("path", "");
+            var generatedElements = new List<StoryboardElement>();
+            var script = LoadScript(path, generatedElements);
+
+            script?.Process(element);
+
+            var state = new ScriptState
+            {
+                SourceElement = element,
+                Time = (float)element.StartTime,
+                Endtime = (float)element.EndTime,
+                Script = script,
+                Elements = generatedElements,
+                Loaded = false
+            };
+
+            state.OnRebuildStart = () =>
+            {
+                state.Loaded = false;
+                syncLoadedRanges();
+            };
+
+            state.OnRebuildFinish = () =>
+            {
+                state.Loaded = true;
+                syncLoadedRanges();
+
+                foreach (var l in state.Elements.Select(e => e.Layer).Distinct())
+                    Updated?.Invoke(l);
+            };
+
+            scripts.Add(state);
+            pendingStates.Add(state);
+            loadQueue.Enqueue(() => activateScriptAsync(state));
+        }
+
+        syncLoadedRanges();
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        processLoadQueue();
+    }
+
+    private void processLoadQueue()
+    {
+        while (loadQueue.Count > 0)
+        {
+            var work = loadQueue.Dequeue();
+            work().ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    Logger.Error(t.Exception, "Error occured during processing load queue for dynamic storyboard");
+            });
+        }
+    }
+
+    private async Task activateScriptAsync(ScriptState state)
+    {
+        if (state.Loaded) return;
+
+        Schedule(() => state.OnRebuildStart?.Invoke());
+
+        try
+        {
+            var byLayer = await Task.Run(() =>
+                state.Elements
+                     .GroupBy(e => e.Layer)
+                     .Select(g => (Layer: g.Key, Elements: g.ToList()))
+                     .ToList()
+            );
+
+            Schedule(() =>
+            {
+                foreach (var (l, elems) in byLayer)
+                    ScriptElementsAdded?.Invoke(l, state.SourceElement, elems);
+
+                state.OnRebuildFinish?.Invoke();
+                pendingStates.Remove(state);
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, $"Failed to activate storyboard script '{state.SourceElement.GetParameter("path", "")}'.");
+            Schedule(() => pendingStates.Remove(state));
+        }
+    }
+
+    // TODO:
+    // Currently this is very manual and tedious.
+    // It should probably be revisited in the future to prevent a desynced state for what relies on LoadedRanges.
+    private void syncLoadedRanges()
+    {
+        LoadedRanges.Clear();
+        LoadedRanges.AddRange(scripts.Select(s => (s.Time, s.Endtime, s.Loaded)));
+    }
+
+    private class ScriptState : IHasLoadedValue
+    {
+        public StoryboardElement SourceElement { get; set; }
+        public float Time;
+        public float Endtime;
+        public float Duration => Endtime - Time;
+
+        public bool Loaded { get; set; }
+
+        public Action OnRebuildStart;
+        public Action OnRebuildFinish;
+
+        public StoryboardScriptRunner Script;
+        public List<StoryboardElement> Elements { get; set; } = new();
+    }
+}

--- a/fluXis/Storyboards/Drawables/DrawableDynamicStoryboardLayer.cs
+++ b/fluXis/Storyboards/Drawables/DrawableDynamicStoryboardLayer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using fluXis.Storyboards.Drawables.Elements;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+
+namespace fluXis.Storyboards.Drawables;
+
+public partial class DrawableDynamicStoryboardLayer : DrawSizePreservingFillContainer
+{
+    private IFrameBasedClock clock { get; }
+    private DrawableDynamicStoryboard storyboard { get; }
+    private StoryboardLayer layer { get; }
+    private DependencyContainer dependencies;
+
+    private DrawableMutableStoryboardCompound masterCompound;
+    private Dictionary<StoryboardElement, DrawableMutableStoryboardCompound> scriptDrawables { get; } = new();
+
+    public DrawableDynamicStoryboardLayer(IFrameBasedClock clock, DrawableDynamicStoryboard storyboard, StoryboardLayer layer)
+    {
+        this.clock = clock;
+        this.storyboard = storyboard;
+        this.layer = layer;
+    }
+
+    // Some clarification:
+    // We call normal (non script created) elements as 'static' because we don't need to track it to rebuild it.
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        RelativeSizeAxes = Axes.Both;
+        TargetDrawSize = storyboard.BindableStoryboard.Value.Resolution;
+
+        dependencies.CacheAs(clock);
+        dependencies.CacheAs<DrawableStoryboard>(storyboard);
+        dependencies.CacheAs(storyboard.Storage);
+
+        Child = masterCompound = new DrawableMutableStoryboardCompound(createCompoundElement(), []);
+        buildStatic();
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        storyboard.ScriptElementsAdded += onScriptElementsAdded;
+        storyboard.ScriptElementsRemoved += onScriptElementsRemoved;
+    }
+
+    #region Building
+
+    private void buildStatic()
+    {
+        var elements = storyboard.BindableStoryboard.Value.Elements
+                                 .Where(x => x.Layer == layer && x.Type != StoryboardElementType.Script);
+
+        foreach (var element in elements)
+            AddStaticElement(element);
+    }
+
+    public void RebuildStatic() => buildStatic();
+
+    #endregion
+
+    #region Event Handling
+
+    private void onScriptElementsAdded(StoryboardLayer l, StoryboardElement source, IEnumerable<StoryboardElement> elements)
+    {
+        if (l != layer) return;
+
+        // We have to remove old elements (if it exists) to prevent duplication
+        onScriptElementsRemoved(l, source);
+
+        // we create a new compound for every script element. this doesn't match our normal DrawableStoryboardLayer,
+        // but it's definitely cleaner and more effective to do so
+        var compound = new DrawableMutableStoryboardCompound(createCompoundElement(), elements.ToList());
+        scriptDrawables[source] = compound;
+        Add(compound);
+    }
+
+    private void onScriptElementsRemoved(StoryboardLayer l, StoryboardElement source)
+    {
+        if (l != layer) return;
+
+        if (scriptDrawables.Remove(source, out var existing))
+            existing.Expire();
+    }
+
+    #endregion
+
+    #region Creation
+
+    private StoryboardElement createCompoundElement() => new()
+    {
+        Type = StoryboardElementType.Compound,
+        Width = TargetDrawSize.X,
+        Height = TargetDrawSize.Y,
+        Anchor = Anchor.Centre,
+        Origin = Anchor.Centre
+    };
+
+    public void AddStaticElement(StoryboardElement element)
+    {
+        if (element.Layer == layer)
+            masterCompound.AddElement(element);
+    }
+
+    public void RemoveStaticElement(StoryboardElement element) => masterCompound.RemoveElement(element);
+
+    public void UpdateStaticElement(StoryboardElement element)
+    {
+        masterCompound.RemoveElement(element);
+        AddStaticElement(element);
+    }
+
+    #endregion
+
+    protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+    protected override void Dispose(bool isDisposing)
+    {
+        base.Dispose(isDisposing);
+        storyboard.ScriptElementsAdded -= onScriptElementsAdded;
+        storyboard.ScriptElementsRemoved -= onScriptElementsRemoved;
+    }
+}

--- a/fluXis/Storyboards/Drawables/DrawableDynamicStoryboardLayer.cs
+++ b/fluXis/Storyboards/Drawables/DrawableDynamicStoryboardLayer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using fluXis.Storyboards.Drawables.Elements;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -73,33 +74,67 @@ public partial class DrawableDynamicStoryboardLayer : DrawSizePreservingFillCont
         // We have to remove old elements (if it exists) to prevent duplication
         onScriptElementsRemoved(l, source);
 
+        var elementsList = elements.ToList();
+        // micro optimization to speed up iteration instead of using LINQ
+        var span = CollectionsMarshal.AsSpan(elementsList);
+        var startTime = source.StartTime;
+
+        // Relative time doesn't work very well for our use case here so we convert to absolute time.
+        // While we do not inherently need to match the time of the elements created by scripts as of now but,
+        // it might become necessary to do when we can access compounds inside scripts in the future
+        // TODO: remove the above 2 comments after adding compounds to scripts
+        foreach (ref var e in span)
+        {
+            e.StartTime -= startTime;
+            e.EndTime -= startTime;
+        }
+
         // we create a new compound for every script element. this doesn't match our normal DrawableStoryboardLayer,
         // but it's definitely cleaner and more effective to do so
-        var compound = new DrawableMutableStoryboardCompound(createCompoundElement(), elements.ToList());
+        var compoundEl = createCompoundElement(source);
+        var compound = new DrawableMutableStoryboardCompound(compoundEl, elementsList);
         scriptDrawables[source] = compound;
-        Add(compound);
+        masterCompound.AddDrawable(compound, source);
     }
 
     private void onScriptElementsRemoved(StoryboardLayer l, StoryboardElement source)
     {
         if (l != layer) return;
 
-        if (scriptDrawables.Remove(source, out var existing))
-            existing.Expire();
+        if (scriptDrawables.Remove(source, out _))
+            masterCompound.RemoveElement(source);
     }
 
     #endregion
 
     #region Creation
 
-    private StoryboardElement createCompoundElement() => new()
+    /// <summary>
+    /// Use source if you want the compound to inherit some of an element's properties like scripts' start time and zindex
+    /// </summary>
+    private StoryboardElement createCompoundElement(StoryboardElement source = null)
     {
-        Type = StoryboardElementType.Compound,
-        Width = TargetDrawSize.X,
-        Height = TargetDrawSize.Y,
-        Anchor = Anchor.Centre,
-        Origin = Anchor.Centre
-    };
+        var element = new StoryboardElement
+        {
+            Type = StoryboardElementType.Compound,
+            Width = TargetDrawSize.X,
+            Height = TargetDrawSize.Y,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Layer = layer,
+
+            EndTime = double.MaxValue
+        };
+
+        if (source != null)
+        {
+            element.StartTime = source.StartTime;
+            element.EndTime = source.EndTime;
+            element.ZIndex = source.ZIndex;
+        }
+
+        return element;
+    }
 
     public void AddStaticElement(StoryboardElement element)
     {

--- a/fluXis/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/fluXis/Storyboards/Drawables/DrawableStoryboard.cs
@@ -20,16 +20,16 @@ namespace fluXis.Storyboards.Drawables;
 public partial class DrawableStoryboard : CompositeDrawable
 {
     [Resolved]
-    private FluXisConfig config { get; set; }
+    protected FluXisConfig Config { get; private set; }
 
     [Resolved]
-    private ISkin skin { get; set; }
+    protected ISkin Skin { get; private set; }
 
     [Resolved]
-    private AudioAnalyzer audioAnalyzer { get; set; }
+    protected AudioAnalyzer AudioAnalyzer { get; private set; }
 
     public Storyboard Storyboard { get; }
-    private MapInfo map { get; }
+    protected MapInfo Map { get; }
     private string assetPath { get; }
 
     public StoryboardStorage Storage { get; private set; }
@@ -37,7 +37,7 @@ public partial class DrawableStoryboard : CompositeDrawable
 
     public DrawableStoryboard(MapInfo map, Storyboard storyboard, string assetPath)
     {
-        this.map = map;
+        Map = map;
         Storyboard = storyboard;
         this.assetPath = assetPath;
     }
@@ -50,31 +50,36 @@ public partial class DrawableStoryboard : CompositeDrawable
         // wait for FFT data to be ready before scripts can get amplitudes.
         try
         {
-            audioAnalyzer.ComputeComplete.Wait();
+            AudioAnalyzer.ComputeComplete.Wait();
         }
         catch (OperationCanceledException)
         {
             return;
         }
 
+        LoadScripts();
+        Storyboard.Sort();
+    }
+
+    protected virtual void LoadScripts()
+    {
         var elements = Storyboard.Elements.Where(e => e.Type == StoryboardElementType.Script).ToList();
 
         foreach (var element in elements)
         {
-            var script = loadScript(element.GetParameter("path", ""));
+            var script = LoadScript(element.GetParameter("path", ""));
             script?.Process(element);
         }
-
-        Storyboard.Sort();
     }
 
-    private StoryboardScriptRunner loadScript(string path)
+    protected StoryboardScriptRunner LoadScript(string path, List<StoryboardElement> addTo = null)
     {
         if (string.IsNullOrWhiteSpace(path))
             return null;
 
-        if (scripts.TryGetValue(path, out var script))
-            return script;
+        // Only use the cache when not adding into a dedicated list
+        if (addTo == null && scripts.TryGetValue(path, out var cached))
+            return cached;
 
         var full = Storage.Storage.GetFullPath(path);
 
@@ -82,7 +87,10 @@ public partial class DrawableStoryboard : CompositeDrawable
             return null;
 
         var raw = File.ReadAllText(full);
-        var runner = scripts[path] = new StoryboardScriptRunner(map, audioAnalyzer, Storyboard, new LuaSettings(config), skin);
+        var runner = new StoryboardScriptRunner(Map, AudioAnalyzer, Storyboard, new LuaSettings(Config), Skin, addTo);
+
+        if (addTo == null)
+            scripts[path] = runner;
 
         try
         {
@@ -91,6 +99,7 @@ public partial class DrawableStoryboard : CompositeDrawable
         catch (Exception ex)
         {
             ScriptRunner.Logger.Add($"Failed to load script '{path}'.", LogLevel.Error, ex);
+            return null;
         }
 
         return runner;

--- a/fluXis/Storyboards/Drawables/Elements/DrawableMutableStoryboardCompound.cs
+++ b/fluXis/Storyboards/Drawables/Elements/DrawableMutableStoryboardCompound.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace fluXis.Storyboards.Drawables.Elements;
+
+public partial class DrawableMutableStoryboardCompound : DrawableStoryboardCompound
+{
+    private readonly Dictionary<StoryboardElement, DrawableStoryboardElement> elements = new();
+
+    public DrawableMutableStoryboardCompound(StoryboardElement element, List<StoryboardElement> children)
+        : base(element, children)
+    {
+    }
+
+    public void AddElement(StoryboardElement el) => AddDrawable(CreateDrawableFor(el), el);
+
+    public void AddDrawable(DrawableStoryboardElement drawable, StoryboardElement source)
+    {
+        RemoveElement(source);
+        elements[source] = drawable;
+
+        LoadComponentAsync(drawable, d =>
+        {
+            // VERY IMPORTANT If the user updated this element again while we were loading in the background,
+            // this drawable is now obsolete and ee must abort and destroy it so it doesn't duplicate
+            if (elements.GetValueOrDefault(source) != d)
+            {
+                d.Dispose();
+                return;
+            }
+
+            if (d.Element.EndTime < FramedClock.CurrentTime)
+                Past.Push(d);
+            else if (d.Element.StartTime > FramedClock.CurrentTime)
+            {
+                Future.Push(d);
+                sortFuture();
+            }
+            else
+                Container.Add(d);
+        });
+    }
+
+    public void RemoveElement(StoryboardElement el)
+    {
+        if (!elements.Remove(el, out var drawable)) return;
+
+        if (Container.Contains(drawable))
+            Container.Remove(drawable, true);
+        else
+        {
+            if (!removeFromStack(Past, drawable))
+            {
+                if (removeFromStack(Future, drawable))
+                    sortFuture();
+            }
+
+            // If it was stuck in a stack or still loading, dispose of it manually
+            drawable.Expire();
+            drawable.Dispose();
+        }
+    }
+
+    public DrawableStoryboardElement GetDrawable(StoryboardElement el) => elements.GetValueOrDefault(el);
+
+    private static bool removeFromStack(Stack<DrawableStoryboardElement> stack, DrawableStoryboardElement item)
+    {
+        if (!stack.Contains(item)) return false;
+
+        var list = stack.ToList();
+        list.Remove(item);
+        stack.Clear();
+
+        // .ToList() reads from top to bottom
+        // We MUST reverse it to bottom to top before pushing back
+        list.Reverse();
+
+        foreach (var d in list) stack.Push(d);
+        return true;
+    }
+
+    private void sortFuture()
+    {
+        var list = Future.OrderByDescending(x => x.Element.StartTime).ToList();
+        Future.Clear();
+        foreach (var d in list) Future.Push(d);
+    }
+}

--- a/fluXis/Storyboards/Drawables/Elements/DrawableStoryboardCompound.cs
+++ b/fluXis/Storyboards/Drawables/Elements/DrawableStoryboardCompound.cs
@@ -14,120 +14,126 @@ namespace fluXis.Storyboards.Drawables.Elements;
 public partial class DrawableStoryboardCompound : DrawableStoryboardElement
 {
     [Resolved]
-    private IFrameBasedClock clock { get; set; }
+    protected IFrameBasedClock FramedClock { get; private set; }
 
     [Resolved]
-    private DrawableStoryboard storyboard { get; set; }
+    protected DrawableStoryboard Storyboard { get; private set; }
 
-    private int depth;
+    protected int ChildrenDepth;
 
-    private readonly string id = string.Empty;
-    private readonly List<StoryboardElement> children;
+    protected readonly string ID = string.Empty;
+    protected readonly List<StoryboardElement> Children;
 
-    private readonly Stack<DrawableStoryboardElement> past = new();
-    private readonly Stack<DrawableStoryboardElement> future = new();
+    protected readonly Stack<DrawableStoryboardElement> Past = new();
+    protected readonly Stack<DrawableStoryboardElement> Future = new();
 
-    private SortingContainer container;
+    protected SortingContainer Container;
 
     public DrawableStoryboardCompound(StoryboardElement element)
         : this(element, [])
     {
-        id = element.GetParameter("id", "");
+        ID = element.GetParameter("id", "");
     }
 
     public DrawableStoryboardCompound(StoryboardElement element, List<StoryboardElement> children)
         : base(element)
     {
-        this.children = children;
+        Children = children;
 
         if (element.Type != StoryboardElementType.Compound)
             throw new ArgumentException($"Element provided is not {nameof(StoryboardElementType.Compound)}", nameof(element));
     }
 
+    protected DrawableStoryboardElement CreateDrawableFor(StoryboardElement el)
+    {
+        var element = el.JsonCopy();
+        element.StartTime += Element.StartTime;
+        element.EndTime += Element.StartTime;
+
+        var drawable = element.Type switch
+        {
+            StoryboardElementType.Box => new DrawableStoryboardBox(element),
+            StoryboardElementType.Sprite => new DrawableStoryboardSprite(element),
+            StoryboardElementType.Text => new DrawableStoryboardText(element),
+            StoryboardElementType.Circle => new DrawableStoryboardCircle(element),
+            StoryboardElementType.OutlineCircle => new DrawableStoryboardOutlineCircle(element),
+            StoryboardElementType.SkinSprite => new DrawableStoryboardSkinSprite(element),
+            StoryboardElementType.OutlineBox => new DrawableStoryboardOutlineBox(element),
+            StoryboardElementType.Compound => new DrawableMutableStoryboardCompound(element, []),
+            _ => new DrawableStoryboardElement(element)
+        };
+
+        drawable.Clock = FramedClock;
+        return drawable;
+    }
+
     [BackgroundDependencyLoader]
     private void load()
     {
-        if (depth >= 10)
+        if (ChildrenDepth >= 10)
         {
             Logger.Log("Nested compound depth is over 10, no more elements will be created.", LoggingTarget.Runtime, LogLevel.Important);
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(id) && storyboard.Storyboard.Compounds.TryGetValue(id, out var sub))
-            children.AddRange(sub);
+        if (!string.IsNullOrWhiteSpace(ID) && Storyboard.Storyboard.Compounds.TryGetValue(ID, out var sub))
+            Children.AddRange(sub);
 
         var drawables = new List<DrawableStoryboardElement>();
 
-        foreach (var el in children)
+        foreach (var el in Children)
         {
-            var element = el.JsonCopy();
-            element.StartTime += Element.StartTime;
-            element.EndTime += Element.StartTime;
-
-            var drawable = element.Type switch
-            {
-                StoryboardElementType.Box => new DrawableStoryboardBox(element),
-                StoryboardElementType.Sprite => new DrawableStoryboardSprite(element),
-                StoryboardElementType.Text => new DrawableStoryboardText(element),
-                StoryboardElementType.Script => null,
-                StoryboardElementType.Circle => new DrawableStoryboardCircle(element),
-                StoryboardElementType.OutlineCircle => new DrawableStoryboardOutlineCircle(element),
-                StoryboardElementType.SkinSprite => new DrawableStoryboardSkinSprite(element),
-                StoryboardElementType.OutlineBox => new DrawableStoryboardOutlineBox(element),
-                StoryboardElementType.Compound => new DrawableStoryboardCompound(element) { depth = depth + 1 },
-                _ => new DrawableStoryboardElement(element)
-            };
+            var drawable = CreateDrawableFor(el);
 
             if (drawable is null)
                 continue;
 
             // preload to avoid lagspikes when loading sprites
-            drawable.Clock = clock;
             LoadComponent(drawable);
             drawables.Add(drawable);
         }
 
-        InternalChild = container = new SortingContainer
+        InternalChild = Container = new SortingContainer
         {
             RelativeSizeAxes = Axes.Both,
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
-            Clock = clock
+            Clock = FramedClock
         };
 
-        drawables.OrderByDescending(x => x.Element.StartTime).ForEach(x => future.Push(x));
+        drawables.OrderByDescending(x => x.Element.StartTime).ForEach(x => Future.Push(x));
     }
 
     protected override void Update()
     {
         base.Update();
 
-        while (future.Count > 0 && future.Peek().Element.StartTime <= clock.CurrentTime)
+        while (Future.Count > 0 && Future.Peek().Element.StartTime <= FramedClock.CurrentTime)
         {
-            var drawable = future.Pop();
-            container.Add(drawable);
+            var drawable = Future.Pop();
+            Container.Add(drawable);
         }
 
-        var tooEarly = container.Children.Where(c => c.Element.StartTime > clock.CurrentTime).ToList();
+        var tooEarly = Container.Children.Where(c => c.Element.StartTime > FramedClock.CurrentTime).ToList();
 
         foreach (var drawable in tooEarly.OrderByDescending(x => x.Element.StartTime))
         {
-            container.Remove(drawable, false);
-            future.Push(drawable);
+            Container.Remove(drawable, false);
+            Future.Push(drawable);
         }
 
-        var toRemove = container.Children.Where(c => c.Element.EndTime < clock.CurrentTime).ToList();
+        var toRemove = Container.Children.Where(c => c.Element.EndTime < FramedClock.CurrentTime).ToList();
 
         foreach (var drawable in toRemove.OrderBy(x => x.Element.EndTime))
         {
-            container.Remove(drawable, false);
-            past.Push(drawable);
+            Container.Remove(drawable, false);
+            Past.Push(drawable);
         }
 
-        while (past.Count > 0 && past.Peek().Element.EndTime > clock.CurrentTime)
+        while (Past.Count > 0 && Past.Peek().Element.EndTime > FramedClock.CurrentTime)
         {
-            var drawable = past.Pop();
-            container.Add(drawable);
+            var drawable = Past.Pop();
+            Container.Add(drawable);
         }
     }
 
@@ -135,14 +141,14 @@ public partial class DrawableStoryboardCompound : DrawableStoryboardElement
     {
         base.Dispose(isDisposing);
 
-        while (past.TryPop(out var p))
+        while (Past.TryPop(out var p))
             p.Dispose();
 
-        while (future.TryPop(out var f))
+        while (Future.TryPop(out var f))
             f.Dispose();
     }
 
-    private partial class SortingContainer : Container<DrawableStoryboardElement>
+    protected partial class SortingContainer : Container<DrawableStoryboardElement>
     {
         protected override void AddInternal(Drawable drawable)
         {

--- a/fluXis/Storyboards/Drawables/Elements/DrawableStoryboardCompound.cs
+++ b/fluXis/Storyboards/Drawables/Elements/DrawableStoryboardCompound.cs
@@ -104,37 +104,73 @@ public partial class DrawableStoryboardCompound : DrawableStoryboardElement
         drawables.OrderByDescending(x => x.Element.StartTime).ForEach(x => Future.Push(x));
     }
 
+    private double lastTime;
+
     protected override void Update()
     {
         base.Update();
+        double currentTime = FramedClock.CurrentTime;
 
-        while (Future.Count > 0 && Future.Peek().Element.StartTime <= FramedClock.CurrentTime)
+        // this is only used to guarantee that our state will always be correct when seeking
+        // this is still performant since seeking is a one time thing as opposed to constantly updating hundreds of times a second
+        // hardcoded to 2 seconds as we assume that there is no continuous seek/play that is greater than that
+        // we might consider using the current snap divisor (with respect to BPM) when in editor though
+        bool isSeek = Math.Abs(currentTime - lastTime) > 2000 || currentTime < lastTime;
+
+        if (isSeek)
         {
-            var drawable = Future.Pop();
-            Container.Add(drawable);
+            handleSeek(currentTime);
+        }
+        else
+        {
+            while (Future.Count > 0 && Future.Peek().Element.StartTime <= currentTime)
+            {
+                Container.Add(Future.Pop());
+            }
+
+            for (int i = Container.Count - 1; i >= 0; i--)
+            {
+                var drawable = Container[i];
+
+                if (drawable.Element.EndTime < currentTime)
+                {
+                    Container.Remove(drawable, false);
+                    Past.Push(drawable);
+                }
+            }
         }
 
-        var tooEarly = Container.Children.Where(c => c.Element.StartTime > FramedClock.CurrentTime).ToList();
+        lastTime = currentTime;
+    }
 
-        foreach (var drawable in tooEarly.OrderByDescending(x => x.Element.StartTime))
+    private void handleSeek(double currentTime)
+    {
+        var allDrawables = new List<DrawableStoryboardElement>();
+        allDrawables.AddRange(Container.Children);
+
+        while (Past.TryPop(out var p)) allDrawables.Add(p);
+        while (Future.TryPop(out var f)) allDrawables.Add(f);
+
+        Container.Clear(false);
+
+        var futureElements = new List<DrawableStoryboardElement>();
+        var pastElements = new List<DrawableStoryboardElement>();
+
+        foreach (var drawable in allDrawables)
         {
-            Container.Remove(drawable, false);
-            Future.Push(drawable);
+            if (drawable.Element.StartTime > currentTime)
+                futureElements.Add(drawable);
+            else if (drawable.Element.EndTime < currentTime)
+                pastElements.Add(drawable);
+            else
+                Container.Add(drawable);
         }
 
-        var toRemove = Container.Children.Where(c => c.Element.EndTime < FramedClock.CurrentTime).ToList();
+        foreach (var f in futureElements.OrderByDescending(x => x.Element.StartTime))
+            Future.Push(f);
 
-        foreach (var drawable in toRemove.OrderBy(x => x.Element.EndTime))
-        {
-            Container.Remove(drawable, false);
-            Past.Push(drawable);
-        }
-
-        while (Past.Count > 0 && Past.Peek().Element.EndTime > FramedClock.CurrentTime)
-        {
-            var drawable = Past.Pop();
-            Container.Add(drawable);
-        }
+        foreach (var p in pastElements.OrderBy(x => x.Element.EndTime))
+            Past.Push(p);
     }
 
     protected override void Dispose(bool isDisposing)

--- a/fluXis/Storyboards/Storyboard.cs
+++ b/fluXis/Storyboards/Storyboard.cs
@@ -97,6 +97,9 @@ public class Storyboard : EditorMap.IChangeNotifier
         x.EndTime += offset;
     });
 
+    public List<StoryboardElement> GetScriptElements(string s) =>
+        Elements.FindAll(e => e.Type == StoryboardElementType.Script && e.GetParameter("path", "") == s);
+
     public bool Matches(Type type) => typeof(StoryboardElement) == type;
 
     public string Save() => Sort().Serialize();

--- a/fluXis/Storyboards/StoryboardAnimation.cs
+++ b/fluXis/Storyboards/StoryboardAnimation.cs
@@ -10,6 +10,11 @@ namespace fluXis.Storyboards;
 
 public class StoryboardAnimation : ITimedObject, IHasDuration, IHasEasing, IDeepCloneable<StoryboardAnimation>
 {
+    public StoryboardAnimation(StoryboardElement parentElement)
+    {
+        ParentElement = parentElement;
+    }
+
     /// <summary>
     /// The start time of the animation.
     /// </summary>
@@ -75,7 +80,10 @@ public class StoryboardAnimation : ITimedObject, IHasDuration, IHasEasing, IDeep
         }
     }
 
-    public StoryboardAnimation DeepClone() => new()
+    [JsonIgnore]
+    public StoryboardElement ParentElement;
+
+    public StoryboardAnimation DeepClone() => new(ParentElement)
     {
         StartTime = StartTime,
         Duration = Duration,


### PR DESCRIPTION
This pr was detached from:
- #264

### The storyboard is now guaranteed to be NIHAHAHA and so so sogoi omg wow
<img width="551" height="537" alt="{3C41CE15-CED0-4AB0-87E3-576B950C2635}" src="https://github.com/user-attachments/assets/466af91e-f413-4090-b1d6-f0f39ca55750" />



## Changes
- We now keep track of all storyboard elements allowing us to only update what we need, this means too that we don't need idle tracker for normal non-script generated elements as it now updates instantly
- Loading icon now is shown/hidden depending on whether a region is loaded
- Storyboard Animation now has a ParentElement field which allows us to actually rebuild specific elements when animations are updated
- each script's drawables are now put in a dedicated Compound. this is for ease of use. There could probably be a better way but this works.

---
   
### Try It Yourself:

Compare between steam version and this branch
  
- new Dynamic Storyboard: https://fluxis.flux.moe/set/1652
  * Go to storyboard and try adjusting params of any elements