### PR TITLE
add skin editor ui for tint toggles

### DIFF
--- a/fluXis/Screens/Skinning/SkinEditor.cs
+++ b/fluXis/Screens/Skinning/SkinEditor.cs
@@ -59,6 +59,7 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
     private EditorVariableTextBox columnWidthTextBox;
     private EditorVariableToggle receptorsFirstToggle;
     private EditorVariableToggle tintNotesToggle;
+    private EditorVariableToggle tintLongNotesToggle;
     private EditorVariableTextBox receptorsPositionTextBox;
 
     [BackgroundDependencyLoader]
@@ -78,6 +79,7 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
             receptorsFirstToggle.Bindable.Value = mode.ReceptorsFirst;
             receptorsPositionTextBox.TextBox.Text = mode.ReceptorOffset.ToString();
             tintNotesToggle.Bindable.Value = mode.TintNotes;
+            tintLongNotesToggle.Bindable.Value = mode.TintLongNotes;
         });
 
         InternalChild = new EditorKeybindingContainer(this, config.GetBindable<string>(FluXisSetting.EditorKeymap), host)
@@ -189,6 +191,13 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
                                                             TooltipText = "Whether to tint the notes with the map/snap colors.",
                                                             CurrentValue = skinJson.GetKeymode(keyMode.Value).TintNotes,
                                                             OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintNotes = v
+                                                        },
+                                                        tintLongNotesToggle = new EditorVariableToggle
+                                                        {
+                                                            Text = "Tint long notes",
+                                                            TooltipText = "Whether to tint the body and end of a long note with the map/snap colors.",
+                                                            CurrentValue = skinJson.GetKeymode(keyMode.Value).TintLongNotes,
+                                                            OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintLongNotes = v
                                                         },
                                                         new FluXisSpriteText
                                                         {

--- a/fluXis/Screens/Skinning/SkinEditor.cs
+++ b/fluXis/Screens/Skinning/SkinEditor.cs
@@ -204,7 +204,7 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
                                                         tintLongNotesToggle = new EditorVariableToggle
                                                         {
                                                             Text = "Tint long notes",
-                                                            TooltipText = "Whether to tint the body and end of a long note with the map/snap colors. Only applies when \"Tint notes\" is enabled.",
+                                                            TooltipText = "Whether to tint the body and end of a long note with the map/snap colors.\nOnly applies when \"Tint notes\" is enabled.",
                                                             CurrentValue = skinJson.GetKeymode(keyMode.Value).TintLongNotes,
                                                             Enabled = { Value = skinJson.GetKeymode(keyMode.Value).TintNotes },
                                                             OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintLongNotes = v,

--- a/fluXis/Screens/Skinning/SkinEditor.cs
+++ b/fluXis/Screens/Skinning/SkinEditor.cs
@@ -204,7 +204,8 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
                                                             TooltipText = "Whether to tint the body and end of a long note with the map/snap colors. Only applies when \"Tint notes\" is enabled.",
                                                             CurrentValue = skinJson.GetKeymode(keyMode.Value).TintLongNotes,
                                                             Enabled = { Value = skinJson.GetKeymode(keyMode.Value).TintNotes },
-                                                            OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintLongNotes = v
+                                                            OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintLongNotes = v,
+                                                            HideWhenDisabled = true
                                                         },
                                                         new FluXisSpriteText
                                                         {

--- a/fluXis/Screens/Skinning/SkinEditor.cs
+++ b/fluXis/Screens/Skinning/SkinEditor.cs
@@ -60,6 +60,7 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
     private EditorVariableToggle receptorsFirstToggle;
     private EditorVariableToggle tintNotesToggle;
     private EditorVariableToggle tintLongNotesToggle;
+    private EditorVariableToggle tintReceptorsToggle;
     private EditorVariableTextBox receptorsPositionTextBox;
 
     [BackgroundDependencyLoader]
@@ -82,6 +83,8 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
 
             tintLongNotesToggle.Enabled.Value = mode.TintNotes;
             tintLongNotesToggle.Bindable.Value = mode.TintLongNotes;
+
+            tintReceptorsToggle.Bindable.Value = mode.TintReceptors;
         });
 
         InternalChild = new EditorKeybindingContainer(this, config.GetBindable<string>(FluXisSetting.EditorKeymap), host)
@@ -206,6 +209,13 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
                                                             Enabled = { Value = skinJson.GetKeymode(keyMode.Value).TintNotes },
                                                             OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintLongNotes = v,
                                                             HideWhenDisabled = true
+                                                        },
+                                                        tintReceptorsToggle = new EditorVariableToggle
+                                                        {
+                                                            Text = "Tint receptors",
+                                                            TooltipText = "Whether to tint the receptors with the map/snap colors.",
+                                                            CurrentValue = skinJson.GetKeymode(keyMode.Value).TintReceptors,
+                                                            OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintReceptors = v
                                                         },
                                                         new FluXisSpriteText
                                                         {

--- a/fluXis/Screens/Skinning/SkinEditor.cs
+++ b/fluXis/Screens/Skinning/SkinEditor.cs
@@ -79,6 +79,8 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
             receptorsFirstToggle.Bindable.Value = mode.ReceptorsFirst;
             receptorsPositionTextBox.TextBox.Text = mode.ReceptorOffset.ToString();
             tintNotesToggle.Bindable.Value = mode.TintNotes;
+
+            tintLongNotesToggle.Enabled.Value = mode.TintNotes;
             tintLongNotesToggle.Bindable.Value = mode.TintLongNotes;
         });
 
@@ -190,13 +192,18 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
                                                             Text = "Tint notes",
                                                             TooltipText = "Whether to tint the notes with the map/snap colors.",
                                                             CurrentValue = skinJson.GetKeymode(keyMode.Value).TintNotes,
-                                                            OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintNotes = v
+                                                            OnValueChanged = v =>
+                                                            {
+                                                                skinJson.GetKeymode(keyMode.Value).TintNotes = v;
+                                                                tintLongNotesToggle.Enabled.Value = v;
+                                                            }
                                                         },
                                                         tintLongNotesToggle = new EditorVariableToggle
                                                         {
                                                             Text = "Tint long notes",
-                                                            TooltipText = "Whether to tint the body and end of a long note with the map/snap colors.",
+                                                            TooltipText = "Whether to tint the body and end of a long note with the map/snap colors. Only applies when \"Tint notes\" is enabled.",
                                                             CurrentValue = skinJson.GetKeymode(keyMode.Value).TintLongNotes,
+                                                            Enabled = { Value = skinJson.GetKeymode(keyMode.Value).TintNotes },
                                                             OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintLongNotes = v
                                                         },
                                                         new FluXisSpriteText

--- a/fluXis/Screens/Skinning/SkinEditor.cs
+++ b/fluXis/Screens/Skinning/SkinEditor.cs
@@ -58,6 +58,7 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
     private EditorVariableTextBox hitPositionTextBox;
     private EditorVariableTextBox columnWidthTextBox;
     private EditorVariableToggle receptorsFirstToggle;
+    private EditorVariableToggle tintNotesToggle;
     private EditorVariableTextBox receptorsPositionTextBox;
 
     [BackgroundDependencyLoader]
@@ -76,6 +77,7 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
             columnWidthTextBox.TextBox.Text = mode.ColumnWidth.ToString();
             receptorsFirstToggle.Bindable.Value = mode.ReceptorsFirst;
             receptorsPositionTextBox.TextBox.Text = mode.ReceptorOffset.ToString();
+            tintNotesToggle.Bindable.Value = mode.TintNotes;
         });
 
         InternalChild = new EditorKeybindingContainer(this, config.GetBindable<string>(FluXisSetting.EditorKeymap), host)
@@ -180,6 +182,13 @@ public partial class SkinEditor : FluXisScreen, IKeyBindingHandler<FluXisGlobalK
                                                                 else
                                                                     box.NotifyError();
                                                             }
+                                                        },
+                                                        tintNotesToggle = new EditorVariableToggle
+                                                        {
+                                                            Text = "Tint notes",
+                                                            TooltipText = "Whether to tint the notes with the map/snap colors.",
+                                                            CurrentValue = skinJson.GetKeymode(keyMode.Value).TintNotes,
+                                                            OnValueChanged = v => skinJson.GetKeymode(keyMode.Value).TintNotes = v
                                                         },
                                                         new FluXisSpriteText
                                                         {

--- a/fluXis/Skinning/Json/SkinKeymode.cs
+++ b/fluXis/Skinning/Json/SkinKeymode.cs
@@ -26,7 +26,6 @@ public class SkinKeymode
 
     /// <summary>
     /// tints the receptors.
-    /// only applies when <see cref="TintReceptors"/> is true.
     /// </summary>
     [JsonProperty("tint_receptors")]
     public bool TintReceptors { get; set; } = false;


### PR DESCRIPTION
fixes #276

<img width="1368" height="800" alt="image" src="https://github.com/user-attachments/assets/164eaef8-b0f5-4dc5-be63-c1417d39fb61" />


`tint_lns` toggle is hidden when `tint_notes` is false

`tint_receptors` is missing from wiki documentation. should add