### PR TITLE
Prevent crash from non-finite progress bar width

### DIFF
--- a/fluXis/Overlay/Music/MusicPlayer.cs
+++ b/fluXis/Overlay/Music/MusicPlayer.cs
@@ -299,7 +299,8 @@ public partial class MusicPlayer : OverlayContainer, IKeyBindingHandler<FluXisGl
         globalBackground.Alpha = screens.Alpha = dim.Alpha = animationProgress >= 1f ? 0 : 1;
         backgrounds.Alpha = video.Alpha >= 1f ? 0 : 1;
 
-        progress.Width = (float)((globalClock.CurrentTrack?.CurrentTime ?? 0) / (globalClock.CurrentTrack?.Length ?? 1000));
+        float width = (float)((globalClock.CurrentTrack?.CurrentTime ?? 0) / (globalClock.CurrentTrack?.Length ?? 1000));
+        progress.Width = float.IsFinite(width) ? width : 0;
 
         pausePlay.IconSprite.Icon = globalClock.IsRunning ? Phosphor.Bold.Pause : Phosphor.Bold.Play;
         fullscreenToggle.IconSprite.Icon = fullscreen ? Phosphor.Bold.ArrowsInSimple : Phosphor.Bold.ArrowsOutSimple;


### PR DESCRIPTION
Fixes InventiveRhythm/fluXis#273

## Type
Crash/Exception

## Version
main branch / v2026.414.0

## Summary

When a beat map doesn't have a valid song,
the calculation of the progress bar width in `MusicPlayer.cs` throws an ArgumentException.

Simply fixed in this PR by adding an IsFinite check and defaulting to 0 if it in fact is.
Prevents the application from freezing up.

## Tests

Tested it myself. The progress bar is simply not present if the song file is broken.
Other maps have a normal progress bar in the music player.