### PR TITLE
don't try connecting to spectator server without credentials

### DIFF
--- a/fluXis/FluXisGame.cs
+++ b/fluXis/FluXisGame.cs
@@ -137,7 +137,6 @@ public partial class FluXisGame : FluXisGameBase, IKeyBindingHandler<FluXisGloba
         // GameDependencies.CacheAs<IAmplitudeProvider>(globalClock);
 
         loadComponent(NotificationManager, Add);
-        loadComponent<SpectatorClient>(new OnlineSpectatorClient(), Add, true);
 
         loadComponent(globalBackground = new GlobalBackground { InitialDim = 1 }, buffer.Add, true);
         loadComponent(screenContainer = new Container { RelativeSizeAxes = Axes.Both }, buffer.Add);
@@ -272,6 +271,7 @@ public partial class FluXisGame : FluXisGameBase, IKeyBindingHandler<FluXisGloba
         void cont()
         {
             APIClient.TryConnecting();
+            loadComponent<SpectatorClient>(new OnlineSpectatorClient(), Add, true);
             c();
         }
     }

--- a/fluXis/FluXisGame.cs
+++ b/fluXis/FluXisGame.cs
@@ -95,6 +95,8 @@ public partial class FluXisGame : FluXisGameBase, IKeyBindingHandler<FluXisGloba
 
     private GlobalFFTProcessor fftProcessor;
 
+    private OnlineSpectatorClient spectatorClient;
+
     private SentryClient sentry { get; }
 
     private bool isExiting;
@@ -137,6 +139,7 @@ public partial class FluXisGame : FluXisGameBase, IKeyBindingHandler<FluXisGloba
         // GameDependencies.CacheAs<IAmplitudeProvider>(globalClock);
 
         loadComponent(NotificationManager, Add);
+        loadComponent<SpectatorClient>(spectatorClient = new OnlineSpectatorClient(), Add, true);
 
         loadComponent(globalBackground = new GlobalBackground { InitialDim = 1 }, buffer.Add, true);
         loadComponent(screenContainer = new Container { RelativeSizeAxes = Axes.Both }, buffer.Add);
@@ -271,7 +274,7 @@ public partial class FluXisGame : FluXisGameBase, IKeyBindingHandler<FluXisGloba
         void cont()
         {
             APIClient.TryConnecting();
-            loadComponent<SpectatorClient>(new OnlineSpectatorClient(), Add, true);
+            spectatorClient.QueueConnect();
             c();
         }
     }

--- a/fluXis/Online/Spectator/OnlineSpectatorClient.cs
+++ b/fluXis/Online/Spectator/OnlineSpectatorClient.cs
@@ -18,13 +18,7 @@ public partial class OnlineSpectatorClient : SpectatorClient
 
     private TypedWebSocketClient<ISpectatorServer, ISpectatorClient> connection = null!;
 
-    [BackgroundDependencyLoader]
-    private void load()
-    {
-        queueConnect();
-    }
-
-    private void queueConnect() => Scheduler.AddDelayed(connect, 2000);
+    public void QueueConnect() => Scheduler.AddDelayed(connect, 2000);
 
     private void connect() => Task.Run(() =>
     {
@@ -40,14 +34,14 @@ public partial class OnlineSpectatorClient : SpectatorClient
         catch (Exception ex)
         {
             Logger.Error(ex, "Failed to connect to spectator server!", LoggingTarget.Network);
-            queueConnect();
+            QueueConnect();
         }
     });
 
     protected override void TriggerDisconnect()
     {
         base.TriggerDisconnect();
-        queueConnect();
+        QueueConnect();
     }
 
     protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
right now, if the user isn't logged it, the game will try to connect to the spectator server every 2 seconds even though we have no credentials (and never will for this session, because logging in requires restarting the game)

~~with this pr, the spectator client only gets loaded if logging in is successful at the start of the game
i don't know if there is a cleaner way of handling this, feels weird to have a loadComponent call super far away from all the others, but at least it doesn't spam the console every 2 seconds~~