### PR TITLE
ScrollGroup: use binary search for SV lookups + don't cast time to int

### DIFF
--- a/fluXis/Screens/Gameplay/Ruleset/ScrollGroup.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/ScrollGroup.cs
@@ -41,10 +41,15 @@ public partial class ScrollGroup : Component
 
         if (index == -1)
         {
-            for (index = 0; index < velocities.Count; index++)
+            index = velocities.BinarySearch(new ScrollVelocity { Time = time }, Comparer<ScrollVelocity>.Create((a, b) => a.Time.CompareTo(b.Time)));
+
+            if (index < 0)
+                index = ~index;
+            else
             {
-                if (time < velocities[index].Time)
-                    break;
+                // if there are multiple SVs stacked together at the same time then we want to use the last one
+                while (index < velocities.Count && velocities[index].Time == time)
+                    index++;
             }
         }
 
@@ -75,7 +80,7 @@ public partial class ScrollGroup : Component
             var prev = velocities[i - 1];
             var current = velocities[i];
 
-            time += (int)((current.Time - prev.Time) * prev.Multiplier);
+            time += (current.Time - prev.Time) * prev.Multiplier;
             marks.Add(time);
         }
     }


### PR DESCRIPTION
that sure is a lot of yapping for the quantity of code changed huh

### tl;dr these are changes to make sv more performant and accurate
(the "partially" and "not addressed" sections are probably worth reading though)

----------------

ok so, i recently tried to make the following quaver map work on fluxis: https://quavergame.com/mapset/map/147044

it had multiple issues, such as the sv effects not looking exactly the same, really poor performance for some parts, and some notes not rendering

this PR addresses that first point and partially addresses the second one

i have recorded a video comparing how that map looks on the current steam version (left), on this pr (middle) and on quaver (right)
https://www.youtube.com/watch?v=lM2Cr1vAqc0

basically, here are the main differences that are addressed with this pr:
1:40 on onward: the arrows' shape is incorrect
2:05 and onward: the memorization parts look broken
3:43: the gray notes that act as receptors have an incorrect location, and don't follow quaver really well, also sometimes the notes you need to hit don't line up with them
4:01: the flickering notes you need to hit aren't supposed to move
all of these are fixed by not casting the time to int in InitMarkers

partially "addressed":
huge lag spikes at 1:50, 3:52 (there are a few other ones but these are the most noticeable), these are due to the way HitObjectColumn spawns and removes objects that are visible or not. it heavily rely on the assumption that only the last visible hitobject can go off screen after being spawned, which might not be the case, and it also consider notes below the receptors as "visible". in this case, due to the various teleports in the map, the notes we are hitting in these section are visually a lot further in the map, and the way the SVs are laid out causes all objects that are visually below these notes to be loaded, which is a huge part of the map. with this pr, the cost of having all these notes loaded is significantly lower now that we are using binary search in PositionFromTime, but ideally we'd still want to have these unloaded

not addressed:
1:47: notes not rendering. this is also due to HitObjectColulmn, which assume that the FutureHitObject with the lowest time will be the next note that will be visible, which isn't the case on that section of the map (on quaver, we aren't actually hitting the notes that are being displayed there, at each "note" there are two teleports to hit notes that are visually at some other places on the map, so we're actually hitting some notes that are somewhere else in the map visually, we just cant notice the teleports because it happens really fast)


i want to address these things in another pr, because this is a lot more complex.
(i already have something locally but it would need further discussion probably)

thx for listening to my ted talk